### PR TITLE
Add all notification data, as received from caller extension, to PendingIntent for tracking

### DIFF
--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
@@ -162,8 +162,7 @@ object NotificationBuilder {
             Log.trace(
                 LOG_TAG,
                 SELF_TAG,
-                "Broadcast receiver class is null, will not schedule a notification from the received" +
-                    " intent with action ${remindLaterIntent.action}"
+                "Broadcast receiver class is null, cannot schedule notification for later."
             )
             tag?.let { notificationManager.cancel(tag.hashCode()) }
             return

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/PushTemplateConstants.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/PushTemplateConstants.kt
@@ -40,6 +40,7 @@ object PushTemplateConstants {
     object NotificationAction {
         const val DISMISSED = "Notification Dismissed"
         const val CLICKED = "Notification Clicked"
+        const val INPUT_RECEIVED = "Input Received"
     }
     object TrackingKeys {
         const val ACTION_ID = "actionId"

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/PushTemplateConstants.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/PushTemplateConstants.kt
@@ -181,9 +181,6 @@ object PushTemplateConstants {
     object IntentKeys {
         const val CENTER_IMAGE_INDEX = "centerImageIndex"
         const val CATALOG_ITEM_INDEX = "catalogItemIndex"
-        const val IMAGE_URLS = "imageUrls"
-        const val IMAGE_CAPTIONS = "imageCaptions"
-        const val IMAGE_CLICK_ACTIONS = "imageClickActions"
         const val RATING_SELECTED = "ratingSelected"
     }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
@@ -89,7 +89,7 @@ internal object PendingIntentUtils {
      * notification
      * @param actionUri the action uri
      * @param actionID the action ID
-     * @param stickyNotification [Boolean] if false, remove the notification after it is interacted with
+     * @param intentExtras the [Bundle] containing the extras to be added to the intent
      * @return the created [PendingIntent]
      */
     internal fun createPendingIntentForTrackerActivity(
@@ -97,8 +97,6 @@ internal object PendingIntentUtils {
         trackerActivityClass: Class<out Activity>?,
         actionUri: String?,
         actionID: String?,
-        tag: String?,
-        stickyNotification: Boolean,
         intentExtras: Bundle?
     ): PendingIntent? {
         val intent = Intent(PushTemplateConstants.NotificationAction.CLICKED)
@@ -106,8 +104,6 @@ internal object PendingIntentUtils {
             intent.setClass(context.applicationContext, trackerActivityClass)
         }
         intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.TAG, tag)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.STICKY, stickyNotification.toString())
         // todo revisit if all data is needed for click actions
         intentExtras?.let { intent.putExtras(intentExtras) }
         addActionDetailsToIntent(

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
@@ -18,6 +18,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
 import com.adobe.marketing.mobile.services.Log
 import java.util.Random
@@ -97,7 +98,8 @@ internal object PendingIntentUtils {
         actionUri: String?,
         actionID: String?,
         tag: String?,
-        stickyNotification: Boolean
+        stickyNotification: Boolean,
+        intentExtras: Bundle?
     ): PendingIntent? {
         val intent = Intent(PushTemplateConstants.NotificationAction.CLICKED)
         trackerActivityClass?.let {
@@ -106,6 +108,8 @@ internal object PendingIntentUtils {
         intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
         intent.putExtra(PushTemplateConstants.PushPayloadKeys.TAG, tag)
         intent.putExtra(PushTemplateConstants.PushPayloadKeys.STICKY, stickyNotification.toString())
+        // todo revisit if all data is needed for click actions
+        intentExtras?.let { intent.putExtras(intentExtras) }
         addActionDetailsToIntent(
             intent,
             actionUri,

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AEPPushNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AEPPushNotificationBuilder.kt
@@ -102,9 +102,7 @@ internal object AEPPushNotificationBuilder {
                 context,
                 trackerActivityClass,
                 pushTemplate.actionUri,
-                pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false,
-                pushTemplate.data.getBundleWithAllData()
+                pushTemplate.data.getBundle()
             )
             .setNotificationDeleteAction(context, trackerActivityClass)
 
@@ -127,7 +125,7 @@ internal object AEPPushNotificationBuilder {
     internal fun createIntent(action: String, template: AEPPushTemplate): Intent {
         val intent = Intent(action)
         intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        intent.putExtras(template.data.getBundleWithAllData())
+        intent.putExtras(template.data.getBundle())
         return intent
     }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AEPPushNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AEPPushNotificationBuilder.kt
@@ -18,7 +18,6 @@ import android.os.Build
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.notificationbuilder.NotificationConstructionFailedException
-import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
 import com.adobe.marketing.mobile.notificationbuilder.R
 import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setNotificationBackgroundColor
 import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setNotificationBodyTextColor
@@ -104,7 +103,8 @@ internal object AEPPushNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.actionUri,
                 pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false
+                pushTemplate.isNotificationSticky ?: false,
+                pushTemplate.data.getBundleWithAllData()
             )
             .setNotificationDeleteAction(context, trackerActivityClass)
 
@@ -127,72 +127,7 @@ internal object AEPPushNotificationBuilder {
     internal fun createIntent(action: String, template: AEPPushTemplate): Intent {
         val intent = Intent(action)
         intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-
-        // add the notification payload version
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.VERSION, template.payloadVersion)
-
-        // add the notification text information
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.TITLE, template.title)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.BODY, template.body)
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.EXPANDED_BODY_TEXT,
-            template.expandedBodyText
-        )
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.TICKER, template.ticker)
-
-        // add the template type
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE,
-            template.templateType?.value
-        )
-
-        // add the basic media information
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.IMAGE_URL, template.imageUrl)
-
-        // add the notification action information
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.ACTION_URI, template.actionUri)
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.ACTION_TYPE,
-            template.actionType?.name
-        )
-
-        // add the notification icon information
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.SMALL_ICON, template.smallIcon)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.LARGE_ICON, template.largeIcon)
-
-        // add the notification color data
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.TITLE_TEXT_COLOR,
-            template.titleTextColor
-        )
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.BODY_TEXT_COLOR,
-            template.bodyTextColor
-        )
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.BACKGROUND_COLOR,
-            template.backgroundColor
-        )
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.SMALL_ICON_COLOR,
-            template.smallIconColor
-        )
-
-        // add other notification properties
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.TAG, template.tag)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.SOUND, template.sound)
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.BADGE_COUNT,
-            template.badgeCount.toString()
-        )
-        intent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.STICKY,
-            template.isNotificationSticky.toString()
-        )
-
-        // add notification priority and visibility
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.PRIORITY, template.priority.stringValue)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.VISIBILITY, template.visibility.stringValue)
+        intent.putExtras(template.data.getBundleWithAllData())
         return intent
     }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilder.kt
@@ -136,9 +136,7 @@ internal object AutoCarouselNotificationBuilder {
                     R.id.carousel_item_image_view,
                     interactionUri,
                     null,
-                    pushTemplate.tag,
-                    pushTemplate.isNotificationSticky ?: false,
-                    pushTemplate.data.getBundleWithAllData()
+                    pushTemplate.data.getBundle()
                 )
             }
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilder.kt
@@ -137,7 +137,8 @@ internal object AutoCarouselNotificationBuilder {
                     interactionUri,
                     null,
                     pushTemplate.tag,
-                    pushTemplate.isNotificationSticky ?: false
+                    pushTemplate.isNotificationSticky ?: false,
+                    pushTemplate.data.getBundleWithAllData()
                 )
             }
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/BasicNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/BasicNotificationBuilder.kt
@@ -85,7 +85,8 @@ internal object BasicNotificationBuilder {
             trackerActivityClass,
             pushTemplate.actionButtonsList,
             pushTemplate.tag,
-            pushTemplate.isNotificationSticky ?: false
+            pushTemplate.isNotificationSticky ?: false,
+            pushTemplate.data.getBundleWithAllData()
         )
 
         // add a remind later button if we have a label and an epoch or delay timestamp

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/BasicNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/BasicNotificationBuilder.kt
@@ -84,9 +84,7 @@ internal object BasicNotificationBuilder {
             context,
             trackerActivityClass,
             pushTemplate.actionButtonsList,
-            pushTemplate.tag,
-            pushTemplate.isNotificationSticky ?: false,
-            pushTemplate.data.getBundleWithAllData()
+            pushTemplate.data.getBundle()
         )
 
         // add a remind later button if we have a label and an epoch or delay timestamp
@@ -151,6 +149,8 @@ internal object BasicNotificationBuilder {
             PushTemplateConstants.IntentActions.REMIND_LATER_CLICKED,
             pushTemplate
         )
+        remindIntent.putExtra(PushPayloadKeys.CHANNEL_ID, channelId)
+        // todo these already exists in intent, verify if we can remove in future iterations
         remindIntent.putExtra(PushPayloadKeys.REMIND_LATER_TEXT, pushTemplate.remindLaterText)
         remindIntent.putExtra(
             PushPayloadKeys.REMIND_LATER_TIMESTAMP,
@@ -161,7 +161,6 @@ internal object BasicNotificationBuilder {
             pushTemplate.remindLaterDuration.toString()
         )
         remindIntent.putExtra(PushPayloadKeys.ACTION_BUTTONS, pushTemplate.actionButtonsString)
-        remindIntent.putExtra(PushPayloadKeys.CHANNEL_ID, channelId)
 
         broadcastReceiverClass.let {
             remindIntent.setClass(context.applicationContext, broadcastReceiverClass)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/InputBoxNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/InputBoxNotificationBuilder.kt
@@ -17,7 +17,6 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
@@ -164,17 +163,28 @@ internal object InputBoxNotificationBuilder {
         channelId: String,
         pushTemplate: InputBoxPushTemplate
     ): PendingIntent {
-        val inputReceivedIntentExtras = addInputReceivedIntentExtras(
-            channelId,
-            pushTemplate
+        val inputReceivedIntentExtras = pushTemplate.data.getBundle()
+        inputReceivedIntentExtras.putString(PushPayloadKeys.CHANNEL_ID, channelId)
+        // todo these already exists in intent, verify if we can remove in future iterations
+        inputReceivedIntentExtras.putString(
+            PushPayloadKeys.INPUT_BOX_RECEIVER_NAME,
+            pushTemplate.inputBoxReceiverName
         )
-
+        inputReceivedIntentExtras.putString(PushPayloadKeys.INPUT_BOX_HINT, pushTemplate.inputTextHint)
+        inputReceivedIntentExtras.putString(
+            PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT,
+            pushTemplate.feedbackText
+        )
+        inputReceivedIntentExtras.putString(
+            PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE,
+            pushTemplate.feedbackImage
+        )
         val intent = Intent(PushTemplateConstants.NotificationAction.INPUT_RECEIVED)
         trackerActivityClass?.let {
             intent.setClass(context.applicationContext, trackerActivityClass)
         }
         intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        inputReceivedIntentExtras.let { intent.putExtras(inputReceivedIntentExtras) }
+        intent.putExtras(inputReceivedIntentExtras)
 
         // Remote input requires a pending intent to be created with the FLAG_MUTABLE flag
         return PendingIntent.getActivity(
@@ -183,40 +193,5 @@ internal object InputBoxNotificationBuilder {
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
         )
-    }
-
-    /**
-     * Adds the input received intent extras to the [Bundle].
-     *
-     * @param channelId the [String] containing the channel ID to use for the notification
-     * @param pushTemplate the [InputBoxPushTemplate] object containing the input box push template data
-     * @return the [Bundle] containing the input received intent extras
-     */
-    private fun addInputReceivedIntentExtras(
-        channelId: String,
-        pushTemplate: InputBoxPushTemplate
-    ): Bundle {
-        Log.trace(
-            LOG_TAG,
-            SELF_TAG,
-            "Creating a text input received intent from a push template object."
-        )
-
-        val intentExtras = pushTemplate.data.getBundleWithAllData()
-        intentExtras.putString(PushPayloadKeys.CHANNEL_ID, channelId)
-        intentExtras.putString(
-            PushPayloadKeys.INPUT_BOX_RECEIVER_NAME,
-            pushTemplate.inputBoxReceiverName
-        )
-        intentExtras.putString(PushPayloadKeys.INPUT_BOX_HINT, pushTemplate.inputTextHint)
-        intentExtras.putString(
-            PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT,
-            pushTemplate.feedbackText
-        )
-        intentExtras.putString(
-            PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE,
-            pushTemplate.feedbackImage
-        )
-        return intentExtras
     }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/LegacyNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/LegacyNotificationBuilder.kt
@@ -63,9 +63,7 @@ internal object LegacyNotificationBuilder {
                 context,
                 trackerActivityClass,
                 pushTemplate.actionButtonsList,
-                pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false,
-                pushTemplate.data.getBundleWithAllData()
+                pushTemplate.data.getBundle()
             )
             // set custom sound, note this applies to API 25 and lower only as API 26 and up set the
             // sound on the notification channel
@@ -75,9 +73,7 @@ internal object LegacyNotificationBuilder {
                 context,
                 trackerActivityClass,
                 pushTemplate.actionUri,
-                pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false,
-                pushTemplate.data.getBundleWithAllData()
+                pushTemplate.data.getBundle()
             )
             // set notification delete action
             .setNotificationDeleteAction(

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/LegacyNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/LegacyNotificationBuilder.kt
@@ -64,7 +64,8 @@ internal object LegacyNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.actionButtonsList,
                 pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false
+                pushTemplate.isNotificationSticky ?: false,
+                pushTemplate.data.getBundleWithAllData()
             )
             // set custom sound, note this applies to API 25 and lower only as API 26 and up set the
             // sound on the notification channel
@@ -75,7 +76,8 @@ internal object LegacyNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.actionUri,
                 pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false
+                pushTemplate.isNotificationSticky ?: false,
+                pushTemplate.data.getBundleWithAllData()
             )
             // set notification delete action
             .setNotificationDeleteAction(

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ManualCarouselNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ManualCarouselNotificationBuilder.kt
@@ -80,7 +80,6 @@ internal object ManualCarouselNotificationBuilder {
         val imageUris = validCarouselItems.map { it.imageUri }
         val captions = validCarouselItems.map { it.captionText }
         val interactionUris = validCarouselItems.map { it.interactionUri }
-        val fallbackActionUri = pushTemplate.actionUri
 
         // get the indices for the carousel
         val carouselIndices = getCarouselIndices(pushTemplate, imageUris)
@@ -99,7 +98,6 @@ internal object ManualCarouselNotificationBuilder {
             expandedLayout,
             validCarouselItems,
             packageName,
-            fallbackActionUri
         )
 
         val notificationManager =
@@ -200,7 +198,6 @@ internal object ManualCarouselNotificationBuilder {
         expandedLayout: RemoteViews,
         validCarouselItems: List<CarouselPushTemplate.CarouselItem>,
         packageName: String?,
-        fallbackActionUri: String?
     ) {
         if (pushTemplate.carouselLayout == PushTemplateConstants.DefaultValues.FILMSTRIP_CAROUSEL_MODE) {
             populateFilmstripCarouselImages(
@@ -270,6 +267,7 @@ internal object ManualCarouselNotificationBuilder {
      *
      * @param context the current [Context] of the application
      * @param items the list of [CarouselPushTemplate.CarouselItem] objects to be displayed in the carousel
+     * @param packageName the [String] containing the package name of the application
      * @param centerIndex the `Int` index of the center image in the carousel
      * @param pushTemplate the [ManualCarouselPushTemplate] object containing the push template data
      * @param trackerActivityClass the [Class] of the activity that will be used for tracking interactions with the carousel item
@@ -310,9 +308,7 @@ internal object ManualCarouselNotificationBuilder {
                     R.id.carousel_item_image_view,
                     interactionUri,
                     null,
-                    pushTemplate.tag,
-                    pushTemplate.isNotificationSticky ?: true,
-                    pushTemplate.data.getBundleWithAllData()
+                    pushTemplate.data.getBundle()
                 )
             }
 
@@ -395,9 +391,7 @@ internal object ManualCarouselNotificationBuilder {
             R.id.manual_carousel_filmstrip_center,
             interactionUri,
             null,
-            pushTemplate.tag,
-            pushTemplate.isNotificationSticky ?: false,
-            pushTemplate.data.getBundleWithAllData()
+            pushTemplate.data.getBundle()
         )
     }
 
@@ -452,9 +446,7 @@ internal object ManualCarouselNotificationBuilder {
      * @param pushTemplate the [ManualCarouselPushTemplate] object containing the manual carousel push template data
      * @param intentAction [String] containing the intent action
      * @param broadcastReceiverClass the [Class] of the broadcast receiver to set in the created pending intent
-     * @param downloadedImageUris [List] of String` containing the downloaded image URIs
-     * @param imageCaptions `List` of String` containing the image captions
-     * @param imageClickActions `List` of String` containing the image click actions
+     * @param channelId [String] containing the notification channel ID
      * @return the created click [Intent]
      */
     private fun createCarouselNavigationClickPendingIntent(
@@ -469,13 +461,14 @@ internal object ManualCarouselNotificationBuilder {
         }
         val clickIntent = AEPPushNotificationBuilder.createIntent(intentAction, pushTemplate)
         clickIntent.putExtra(PushPayloadKeys.CHANNEL_ID, channelId)
-        clickIntent.putExtra(PushPayloadKeys.CAROUSEL_LAYOUT, pushTemplate.carouselLayout)
-        clickIntent.putExtra(PushPayloadKeys.CAROUSEL_ITEMS, pushTemplate.rawCarouselItems)
-        clickIntent.putExtra(PushPayloadKeys.CAROUSEL_OPERATION_MODE, pushTemplate.carouselMode)
         clickIntent.putExtra(
             PushTemplateConstants.IntentKeys.CENTER_IMAGE_INDEX,
             pushTemplate.centerImageIndex.toString()
         )
+        // todo these already exists in intent, verify if we can remove in future iterations
+        clickIntent.putExtra(PushPayloadKeys.CAROUSEL_LAYOUT, pushTemplate.carouselLayout)
+        clickIntent.putExtra(PushPayloadKeys.CAROUSEL_ITEMS, pushTemplate.rawCarouselItems)
+        clickIntent.putExtra(PushPayloadKeys.CAROUSEL_OPERATION_MODE, pushTemplate.carouselMode)
         broadcastReceiverClass.let {
             clickIntent.setClass(context, broadcastReceiverClass)
         }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilder.kt
@@ -155,9 +155,7 @@ internal object ProductCatalogNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.catalogItems[pushTemplate.currentIndex].uri,
                 PushTemplateConstants.CatalogActionIds.PRODUCT_IMAGE_CLICKED,
-                pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false,
-                pushTemplate.data.getBundleWithAllData()
+                pushTemplate.data.getBundle()
             )
         )
     }
@@ -250,9 +248,7 @@ internal object ProductCatalogNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.ctaButtonUri,
                 PushTemplateConstants.CatalogActionIds.CTA_BUTTON_CLICKED,
-                pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false,
-                pushTemplate.data.getBundleWithAllData()
+                pushTemplate.data.getBundle()
             )
         )
     }
@@ -327,6 +323,11 @@ internal object ProductCatalogNotificationBuilder {
             setClass(context.applicationContext, broadcastReceiverClass)
             putExtra(PushTemplateConstants.PushPayloadKeys.CHANNEL_ID, channelId)
             putExtra(
+                PushTemplateConstants.IntentKeys.CATALOG_ITEM_INDEX,
+                currentIndex.toString()
+            )
+            // todo these already exists in intent, verify if we can remove in future iterations
+            putExtra(
                 PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_TEXT,
                 pushTemplate.ctaButtonText
             )
@@ -349,10 +350,6 @@ internal object ProductCatalogNotificationBuilder {
             putExtra(
                 PushTemplateConstants.PushPayloadKeys.CATALOG_ITEMS,
                 pushTemplate.rawCatalogItems
-            )
-            putExtra(
-                PushTemplateConstants.IntentKeys.CATALOG_ITEM_INDEX,
-                currentIndex.toString()
             )
         }
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilder.kt
@@ -156,7 +156,8 @@ internal object ProductCatalogNotificationBuilder {
                 pushTemplate.catalogItems[pushTemplate.currentIndex].uri,
                 PushTemplateConstants.CatalogActionIds.PRODUCT_IMAGE_CLICKED,
                 pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false
+                pushTemplate.isNotificationSticky ?: false,
+                pushTemplate.data.getBundleWithAllData()
             )
         )
     }
@@ -250,7 +251,8 @@ internal object ProductCatalogNotificationBuilder {
                 pushTemplate.ctaButtonUri,
                 PushTemplateConstants.CatalogActionIds.CTA_BUTTON_CLICKED,
                 pushTemplate.tag,
-                pushTemplate.isNotificationSticky ?: false
+                pushTemplate.isNotificationSticky ?: false,
+                pushTemplate.data.getBundleWithAllData()
             )
         )
     }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
@@ -106,6 +106,8 @@ internal object ProductRatingNotificationBuilder {
 
             // add pending intent for confirm click
             // sticky is set to false as the notification will be dismissed after confirm click
+            val intentExtras = pushTemplate.data.getBundle()
+            intentExtras.putString(PushTemplateConstants.PushPayloadKeys.STICKY, "false")
             val selectedRatingAction = pushTemplate.ratingActionList[pushTemplate.ratingSelected]
             expandedLayout.setRemoteViewClickAction(
                 context,
@@ -113,9 +115,7 @@ internal object ProductRatingNotificationBuilder {
                 R.id.rating_confirm,
                 selectedRatingAction.link,
                 pushTemplate.ratingSelected.toString(),
-                pushTemplate.tag,
-                false,
-                pushTemplate.data.getBundleWithAllData()
+                intentExtras
             )
         } else {
             // hide confirm if no rating is selected
@@ -193,7 +193,16 @@ internal object ProductRatingNotificationBuilder {
         broadcastReceiverClass.let {
             ratingButtonClickIntent.setClass(context.applicationContext, broadcastReceiverClass)
         }
+        ratingButtonClickIntent.putExtra(
+            PushTemplateConstants.PushPayloadKeys.RATING_SELECTED_ICON,
+            pushTemplate.ratingSelectedIcon
+        )
 
+        ratingButtonClickIntent.putExtra(
+            PushTemplateConstants.PushPayloadKeys.CHANNEL_ID,
+            channelId
+        )
+        // todo these already exists in intent, verify if we can remove in future iterations
         ratingButtonClickIntent.putExtra(
             PushTemplateConstants.PushPayloadKeys.RATING_ACTIONS,
             pushTemplate.ratingActionString
@@ -205,15 +214,6 @@ internal object ProductRatingNotificationBuilder {
         ratingButtonClickIntent.putExtra(
             PushTemplateConstants.PushPayloadKeys.RATING_UNSELECTED_ICON,
             pushTemplate.ratingUnselectedIcon
-        )
-        ratingButtonClickIntent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.RATING_SELECTED_ICON,
-            pushTemplate.ratingSelectedIcon
-        )
-
-        ratingButtonClickIntent.putExtra(
-            PushTemplateConstants.PushPayloadKeys.CHANNEL_ID,
-            channelId
         )
 
         return PendingIntent.getBroadcast(

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
@@ -114,7 +114,8 @@ internal object ProductRatingNotificationBuilder {
                 selectedRatingAction.link,
                 pushTemplate.ratingSelected.toString(),
                 pushTemplate.tag,
-                false
+                false,
+                pushTemplate.data.getBundleWithAllData()
             )
         } else {
             // hide confirm if no rating is selected

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
@@ -165,6 +165,7 @@ internal object TimerNotificationBuilder {
      */
     private fun createIntent(template: TimerPushTemplate): Intent {
         val intent = AEPPushNotificationBuilder.createIntent(PushTemplateConstants.IntentActions.TIMER_EXPIRED, template)
+        // todo these already exists in intent, verify if we can remove in future iterations
         intent.putExtra(TimerKeys.ALTERNATE_TITLE, template.alternateTitle)
         intent.putExtra(TimerKeys.ALTERNATE_BODY, template.alternateBody)
         intent.putExtra(TimerKeys.ALTERNATE_EXPANDED_BODY, template.alternateExpandedBody)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
@@ -170,6 +170,10 @@ internal object TimerNotificationBuilder {
         intent.putExtra(TimerKeys.ALTERNATE_EXPANDED_BODY, template.alternateExpandedBody)
         intent.putExtra(TimerKeys.ALTERNATE_IMAGE, template.alternateImage)
         intent.putExtra(TimerKeys.TIMER_COLOR, template.timerColor)
+
+        // remove timer to prevent countdown from being recreated
+        intent.removeExtra(TimerKeys.TIMER_DURATION)
+        intent.removeExtra(TimerKeys.TIMER_END_TIME)
         return intent
     }
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
@@ -165,7 +165,6 @@ internal object TimerNotificationBuilder {
      */
     private fun createIntent(template: TimerPushTemplate): Intent {
         val intent = AEPPushNotificationBuilder.createIntent(PushTemplateConstants.IntentActions.TIMER_EXPIRED, template)
-        intent.putExtra(PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE, template.templateType?.value)
         intent.putExtra(TimerKeys.ALTERNATE_TITLE, template.alternateTitle)
         intent.putExtra(TimerKeys.ALTERNATE_BODY, template.alternateBody)
         intent.putExtra(TimerKeys.ALTERNATE_EXPANDED_BODY, template.alternateExpandedBody)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
@@ -17,6 +17,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.media.RingtoneManager
+import android.os.Bundle
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
@@ -223,7 +224,8 @@ internal fun NotificationCompat.Builder.setNotificationClickAction(
     trackerActivityClass: Class<out Activity>?,
     actionUri: String?,
     tag: String?,
-    stickyNotification: Boolean
+    stickyNotification: Boolean,
+    intentExtras: Bundle?
 ): NotificationCompat.Builder {
     val pendingIntent: PendingIntent? = PendingIntentUtils.createPendingIntentForTrackerActivity(
         context,
@@ -231,7 +233,8 @@ internal fun NotificationCompat.Builder.setNotificationClickAction(
         actionUri,
         null,
         tag,
-        stickyNotification
+        stickyNotification,
+        intentExtras
     )
     setContentIntent(pendingIntent)
     return this
@@ -279,7 +282,8 @@ internal fun NotificationCompat.Builder.addActionButtons(
     trackerActivityClass: Class<out Activity>?,
     actionButtons: List<BasicPushTemplate.ActionButton>?,
     tag: String?,
-    stickyNotification: Boolean
+    stickyNotification: Boolean,
+    intentExtras: Bundle?
 ): NotificationCompat.Builder {
     if (actionButtons.isNullOrEmpty()) {
         return this
@@ -295,7 +299,8 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     eachButton.link,
                     eachButton.label,
                     tag,
-                    stickyNotification
+                    stickyNotification,
+                    intentExtras
                 )
             } else {
                 PendingIntentUtils.createPendingIntentForTrackerActivity(
@@ -304,7 +309,8 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     null,
                     eachButton.label,
                     tag,
-                    stickyNotification
+                    stickyNotification,
+                    intentExtras
                 )
             }
         addAction(0, eachButton.label, pendingIntent)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
@@ -216,15 +216,12 @@ internal fun NotificationCompat.Builder.setLargeIcon(
  * @param context the application [Context]
  * @param trackerActivityClass the [Class] of the activity to set in the created pending intent for tracking purposes
  * @param actionUri `String` containing the action uri
- * @param tag `String` containing the tag to use when scheduling the notification
- * @param stickyNotification `boolean` if false, remove the notification after the `RemoteViews` is pressed
+ * @param intentExtras the [Bundle] containing the extras to be added to the intent
  */
 internal fun NotificationCompat.Builder.setNotificationClickAction(
     context: Context,
     trackerActivityClass: Class<out Activity>?,
     actionUri: String?,
-    tag: String?,
-    stickyNotification: Boolean,
     intentExtras: Bundle?
 ): NotificationCompat.Builder {
     val pendingIntent: PendingIntent? = PendingIntentUtils.createPendingIntentForTrackerActivity(
@@ -232,8 +229,6 @@ internal fun NotificationCompat.Builder.setNotificationClickAction(
         trackerActivityClass,
         actionUri,
         null,
-        tag,
-        stickyNotification,
         intentExtras
     )
     setContentIntent(pendingIntent)
@@ -273,16 +268,12 @@ internal fun NotificationCompat.Builder.setNotificationDeleteAction(
  * @param trackerActivityClass the [Activity] class to use as the tracker activity
  * @param actionButtons list of [BasicPushTemplate.ActionButton] containing action buttons to attach
  * to the notification
- * @param tag `String` containing the tag to use when scheduling the notification
- * @param stickyNotification [Boolean]  if false, remove the notification after the action
- * button is pressed
+ * @param intentExtras the [Bundle] containing the extras to be added to the intent
  */
 internal fun NotificationCompat.Builder.addActionButtons(
     context: Context,
     trackerActivityClass: Class<out Activity>?,
     actionButtons: List<BasicPushTemplate.ActionButton>?,
-    tag: String?,
-    stickyNotification: Boolean,
     intentExtras: Bundle?
 ): NotificationCompat.Builder {
     if (actionButtons.isNullOrEmpty()) {
@@ -298,8 +289,6 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     trackerActivityClass,
                     eachButton.link,
                     eachButton.label,
-                    tag,
-                    stickyNotification,
                     intentExtras
                 )
             } else {
@@ -308,8 +297,6 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     trackerActivityClass,
                     null,
                     eachButton.label,
-                    tag,
-                    stickyNotification,
                     intentExtras
                 )
             }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
@@ -15,6 +15,7 @@ import android.app.Activity
 import android.app.PendingIntent
 import android.content.Context
 import android.graphics.Color
+import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
@@ -189,7 +190,8 @@ internal fun RemoteViews.setRemoteViewClickAction(
     actionUri: String?,
     actionId: String?,
     tag: String?,
-    stickyNotification: Boolean
+    stickyNotification: Boolean,
+    intentExtra: Bundle?
 ) {
     Log.trace(
         LOG_TAG,
@@ -204,7 +206,8 @@ internal fun RemoteViews.setRemoteViewClickAction(
             actionUri,
             actionId,
             tag,
-            stickyNotification
+            stickyNotification,
+            intentExtra
         )
     setOnClickPendingIntent(targetViewResourceId, pendingIntent)
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
@@ -18,7 +18,6 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
-import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants.LOG_TAG
 import com.adobe.marketing.mobile.notificationbuilder.internal.PendingIntentUtils
@@ -180,8 +179,7 @@ internal fun RemoteViews.setRemoteViewImage(
  * @param targetViewResourceId [Int] containing the resource id of the view to attach the click action
  * @param actionUri [String] containing the action uri defined for the push template image
  * @param actionId the [String] containing action id for tracking purposes
- * @param tag [String] containing the tag to use when scheduling the notification
- * @param stickyNotification [Boolean] if false, remove the [NotificationCompat] after the `RemoteViews` is pressed
+ * @param intentExtra the [Bundle] containing the extras to be added to the intent
  */
 internal fun RemoteViews.setRemoteViewClickAction(
     context: Context,
@@ -189,8 +187,6 @@ internal fun RemoteViews.setRemoteViewClickAction(
     targetViewResourceId: Int,
     actionUri: String?,
     actionId: String?,
-    tag: String?,
-    stickyNotification: Boolean,
     intentExtra: Bundle?
 ) {
     Log.trace(
@@ -205,8 +201,6 @@ internal fun RemoteViews.setRemoteViewClickAction(
             trackerActivityClass,
             actionUri,
             actionId,
-            tag,
-            stickyNotification,
             intentExtra
         )
     setOnClickPendingIntent(targetViewResourceId, pendingIntent)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/AEPPushTemplate.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/AEPPushTemplate.kt
@@ -98,7 +98,7 @@ internal sealed class AEPPushTemplate(val data: NotificationData) {
     // Optional, when set to false or unset, the notification is automatically dismissed when the
     // user clicks it in the panel. When set to true, the notification persists even when the user
     // clicks it.
-    internal val isNotificationSticky: Boolean?
+    internal val isNotificationSticky: Boolean
 
     // flag to denote if the PushTemplate was built from an intent
     internal val isFromIntent: Boolean
@@ -144,7 +144,7 @@ internal sealed class AEPPushTemplate(val data: NotificationData) {
         sound = data.getString(PushPayloadKeys.SOUND)
         channelId = data.getString(PushPayloadKeys.CHANNEL_ID)
         badgeCount = data.getInteger(PushPayloadKeys.BADGE_COUNT) ?: 0
-        isNotificationSticky = data.getBoolean(PushPayloadKeys.STICKY)
+        isNotificationSticky = data.getBoolean(PushPayloadKeys.STICKY) ?: false
 
         // extract notification priority and visibility
         priority = NotificationPriority.fromString(data.getString(PushPayloadKeys.PRIORITY))

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/IntentData.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/IntentData.kt
@@ -21,4 +21,7 @@ internal class IntentData(private val extras: Bundle, val actionName: String?) :
     override fun getInteger(key: String): Int? = extras.getString(key)?.toIntOrNull()
     override fun getBoolean(key: String): Boolean? = extras.getString(key)?.toBoolean()
     override fun getLong(key: String): Long? = extras.getString(key)?.toLongOrNull()
+    override fun getBundleWithAllData(): Bundle {
+        return extras
+    }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/IntentData.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/IntentData.kt
@@ -21,7 +21,7 @@ internal class IntentData(private val extras: Bundle, val actionName: String?) :
     override fun getInteger(key: String): Int? = extras.getString(key)?.toIntOrNull()
     override fun getBoolean(key: String): Boolean? = extras.getString(key)?.toBoolean()
     override fun getLong(key: String): Long? = extras.getString(key)?.toLongOrNull()
-    override fun getBundleWithAllData(): Bundle {
+    override fun getBundle(): Bundle {
         return extras
     }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/MapData.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/MapData.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.notificationbuilder.internal.util
 
+import android.os.Bundle
 import com.adobe.marketing.mobile.util.DataReader
 
 /**
@@ -25,4 +26,12 @@ internal class MapData(private val data: Map<String, String>) : NotificationData
         DataReader.optString(data, key, null)?.toBoolean()
 
     override fun getLong(key: String): Long? = DataReader.optString(data, key, null)?.toLongOrNull()
+
+    override fun getBundleWithAllData(): Bundle {
+        val bundle = Bundle()
+        for (key in data.keys) {
+            bundle.putString(key, data[key])
+        }
+        return bundle
+    }
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/MapData.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/MapData.kt
@@ -27,7 +27,7 @@ internal class MapData(private val data: Map<String, String>) : NotificationData
 
     override fun getLong(key: String): Long? = DataReader.optString(data, key, null)?.toLongOrNull()
 
-    override fun getBundleWithAllData(): Bundle {
+    override fun getBundle(): Bundle {
         val bundle = Bundle()
         for (key in data.keys) {
             bundle.putString(key, data[key])

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/NotificationData.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/NotificationData.kt
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile.notificationbuilder.internal.util
 
+import android.os.Bundle
+
 // Interface for abstracting the source of notification properties
 interface NotificationData {
 
@@ -57,4 +59,6 @@ interface NotificationData {
      * @return the long value for the given key, or null if the key is not found or the value is not a long
      */
     fun getLong(key: String): Long?
+
+    fun getBundleWithAllData(): Bundle
 }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/NotificationData.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/util/NotificationData.kt
@@ -60,5 +60,10 @@ interface NotificationData {
      */
     fun getLong(key: String): Long?
 
-    fun getBundleWithAllData(): Bundle
+    /**
+     * Returns a [Bundle] containing all the key-value pairs present in the data.
+     *
+     * @return a [Bundle] containing all the key-value pairs present in the data
+     */
+    fun getBundle(): Bundle
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

+ Added new method in `NotificationData` to get all data present in map/intent as `Bundle` to be added in intent extras. Naming suggestions welcome!
```
    fun getBundleWithAllData(): Bundle
```
+ Removed timer keys from PendingIntent data to avoid countdown from being recreated in case of timer template
+ Changed PendingIntent for input box template to resolve to tracker activity

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
