### PR TITLE
Timer Notification Minimum requirement Android N and above + Fixed bugs

### DIFF
--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
@@ -172,7 +172,7 @@ object NotificationBuilder {
         val scheduledIntent = Intent(PushTemplateConstants.IntentActions.SCHEDULED_NOTIFICATION_BROADCAST)
         scheduledIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         scheduledIntent.putExtras(intentExtras)
-        PendingIntentUtils.scheduledNotifications(context, scheduledIntent, broadcastReceiverClass, triggerTimeInSeconds)
+        PendingIntentUtils.scheduleNotification(context, scheduledIntent, broadcastReceiverClass, triggerTimeInSeconds)
 
         // cancel the displayed notification
         tag?.let { notificationManager.cancel(tag.hashCode()) }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
@@ -172,7 +172,7 @@ object NotificationBuilder {
         val scheduledIntent = Intent(PushTemplateConstants.IntentActions.SCHEDULED_NOTIFICATION_BROADCAST)
         scheduledIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         scheduledIntent.putExtras(intentExtras)
-        PendingIntentUtils.createPendingIntentForScheduledNotifications(context, scheduledIntent, broadcastReceiverClass, triggerTimeInSeconds)
+        PendingIntentUtils.scheduledNotifications(context, scheduledIntent, broadcastReceiverClass, triggerTimeInSeconds)
 
         // cancel the displayed notification
         tag?.let { notificationManager.cancel(tag.hashCode()) }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
@@ -27,7 +27,7 @@ internal object PendingIntentUtils {
 
     private const val SELF_TAG = "PendingIntentUtils"
 
-    internal fun scheduledNotifications(
+    internal fun scheduleNotification(
         context: Context,
         scheduledIntent: Intent,
         broadcastReceiverClass: Class<out BroadcastReceiver>?,

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
@@ -27,7 +27,7 @@ internal object PendingIntentUtils {
 
     private const val SELF_TAG = "PendingIntentUtils"
 
-    internal fun createPendingIntentForScheduledNotifications(
+    internal fun scheduledNotifications(
         context: Context,
         scheduledIntent: Intent,
         broadcastReceiverClass: Class<out BroadcastReceiver>?,

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/MultiIconNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/MultiIconNotificationBuilder.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.notificationbuilder.internal.builders
 import android.app.Activity
 import android.app.NotificationManager
 import android.content.Context
+import android.os.Bundle
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.notificationbuilder.NotificationConstructionFailedException
@@ -64,13 +65,15 @@ internal object MultiIconNotificationBuilder {
             pushTemplate
         )
 
+        val closeButtonIntentExtra = Bundle(pushTemplate.data.getBundle()) // copy the bundle
+        closeButtonIntentExtra.putString(PushTemplateConstants.PushPayloadKeys.STICKY, "false")
         notificationLayout.setRemoteViewClickAction(
             context,
             trackerActivityClass,
             R.id.five_icon_close_button,
             null,
             null,
-            pushTemplate.data.getBundle()
+            closeButtonIntentExtra
         )
 
         return AEPPushNotificationBuilder.construct(

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
@@ -16,6 +16,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
@@ -106,8 +107,8 @@ internal object ProductRatingNotificationBuilder {
 
             // add pending intent for confirm click
             // sticky is set to false as the notification will be dismissed after confirm click
-            val intentExtras = pushTemplate.data.getBundle()
-            intentExtras.putString(PushTemplateConstants.PushPayloadKeys.STICKY, "false")
+            val ratingConfirmedIntentExtras = Bundle(pushTemplate.data.getBundle()) // copy the bundle
+            ratingConfirmedIntentExtras.putString(PushTemplateConstants.PushPayloadKeys.STICKY, "false")
             val selectedRatingAction = pushTemplate.ratingActionList[pushTemplate.ratingSelected]
             expandedLayout.setRemoteViewClickAction(
                 context,
@@ -115,7 +116,7 @@ internal object ProductRatingNotificationBuilder {
                 R.id.rating_confirm,
                 selectedRatingAction.link,
                 pushTemplate.ratingSelected.toString(),
-                intentExtras
+                ratingConfirmedIntentExtras
             )
         } else {
             // hide confirm if no rating is selected

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.notificationbuilder.internal.builders
 import android.app.Activity
 import android.app.AlarmManager
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -27,6 +26,7 @@ import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants.LOG_TAG
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants.PushPayloadKeys.TimerKeys
 import com.adobe.marketing.mobile.notificationbuilder.R
+import com.adobe.marketing.mobile.notificationbuilder.internal.PendingIntentUtils
 import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.createNotificationChannelIfRequired
 import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setRemoteViewImage
 import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setTimerTextColor
@@ -58,11 +58,15 @@ internal object TimerNotificationBuilder {
         broadcastReceiverClass: Class<out BroadcastReceiver>?
     ): NotificationCompat.Builder {
 
-        Log.trace(LOG_TAG, TAG, "Building a timer template push notification.")
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            throw NotificationConstructionFailedException("Timer push notification on devices below Android N is not supported.")
+        }
 
         if (!isExactAlarmsAllowed(context)) {
-            throw NotificationConstructionFailedException("Exact alarms are not allowed on this device.")
+            throw NotificationConstructionFailedException("Exact alarms are not allowed on this device. Ignoring to build Timer template push notifications.")
         }
+
+        Log.trace(LOG_TAG, TAG, "Building a timer template push notification.")
 
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -106,15 +110,20 @@ internal object TimerNotificationBuilder {
             }
 
             // create the pending intent for the timer expiry
-            val pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
-
-            // todo replace this with PendingIntentUtils.createPendingIntentForScheduledNotifications
-            // set the alarm manager to trigger the intent at the expiry time
-            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-            val triggerTime = TimeUtils.getUnixTimeInSeconds() + remainingTimeInSeconds
-            val triggerTimeAtMillis = triggerTime * 1000
-            alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerTimeAtMillis, pendingIntent)
+            PendingIntentUtils.scheduledNotifications(context, intent, broadcastReceiverClass, TimeUtils.getUnixTimeInSeconds() + remainingTimeInSeconds)
+        } else {
+            // Before displaying the expired view, check if the notification is still active
+            val notification = notificationManager.activeNotifications.find { it.id == template.tag?.hashCode() }
+            if (notification == null) {
+                Log.debug(
+                    LOG_TAG, TAG,
+                    "Notification with tag '${template.tag}' is not present in the system tray. " +
+                        "The timer notification has already been dismissed. The expired view will not be displayed."
+                )
+                throw NotificationConstructionFailedException("Timer Notification cancelled. Expired view will not be displayed.")
+            }
         }
+
         return notificationBuilder
     }
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/TimerNotificationBuilder.kt
@@ -110,7 +110,7 @@ internal object TimerNotificationBuilder {
             }
 
             // create the pending intent for the timer expiry
-            PendingIntentUtils.scheduledNotifications(context, intent, broadcastReceiverClass, TimeUtils.getUnixTimeInSeconds() + remainingTimeInSeconds)
+            PendingIntentUtils.scheduleNotification(context, intent, broadcastReceiverClass, TimeUtils.getUnixTimeInSeconds() + remainingTimeInSeconds)
         } else {
             // Before displaying the expired view, check if the notification is still active
             val notification = notificationManager.activeNotifications.find { it.id == template.tag?.hashCode() }


### PR DESCRIPTION
Two reasons for bumping up the Timer Notification Minimum requirement
1. NotificationManager.getActiveNotifications() API required to verify if the notification was already dismissed before displaying the expired view is available from Android M and above only
https://developer.android.com/reference/android/app/NotificationManager#getActiveNotifications()
2.  The setChronoMeterCountDown API is available only Android N and above that makes the timer count backwards (https://developer.android.com/reference/android/app/Notification.Builder#setChronometerCountDown(boolean))


Rename `createPendingIntentForScheduledNotifications` to `ScheduleNotification` and use this utility method for TimerTemplate