### PR TITLE
MOB-21015: Add unit tests for NotificationManagerExtensions

### DIFF
--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationManagerExtensionsTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationManagerExtensionsTest.kt
@@ -1,0 +1,90 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.extensions
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.media.RingtoneManager
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.BasicPushTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_CHANNEL_ID
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MockAEPPushTemplateDataProvider
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.provideMockedBasicPushTemplateWithAllKeys
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.provideMockedBasicPushTemplateWithRequiredData
+import com.adobe.marketing.mobile.notificationbuilder.internal.util.MapData
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [31])
+class NotificationManagerExtensionsTest {
+    @Mock
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        context = RuntimeEnvironment.getApplication()
+    }
+
+    @Test
+    fun `createNotificationChannelIfRequired should create a new channel if it does not exist`() {
+        val template = provideMockedBasicPushTemplateWithRequiredData()
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationChannelId = notificationManager.createNotificationChannelIfRequired(context, template)
+
+        assertEquals(PushTemplateConstants.DefaultValues.DEFAULT_CHANNEL_ID, notificationChannelId)
+    }
+
+    @Test
+    fun `createNotificationChannelIfRequired should not create a new channel if it already exists`() {
+        val template = provideMockedBasicPushTemplateWithAllKeys()
+        val notificationManager = Mockito.mock(NotificationManager::class.java)
+        Mockito.`when`(notificationManager.getNotificationChannel(anyString())).thenReturn(NotificationChannel(MOCKED_CHANNEL_ID, "default_channel_name", NotificationManager.IMPORTANCE_DEFAULT))
+        val notificationChannelId = notificationManager.createNotificationChannelIfRequired(context, template)
+
+        assertEquals(MOCKED_CHANNEL_ID, notificationChannelId)
+    }
+
+    @Test
+    fun `createNotificationChannelIfRequired should set a default sound if template sound is null`() {
+        val template = provideMockedBasicPushTemplateWithRequiredData()
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationChannelId = notificationManager.createNotificationChannelIfRequired(context, template)
+        val notificationChannel = notificationManager.getNotificationChannel(notificationChannelId)
+
+        assertEquals(notificationChannel.sound, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
+    }
+
+    @Test
+    fun `createNotificationChannelIfRequired should set a default sound if template sound is empty`() {
+        val dataMap = MockAEPPushTemplateDataProvider.getMockedAEPDataMapWithAllKeys()
+        dataMap[PushTemplateConstants.PushPayloadKeys.SOUND] = ""
+        val template = BasicPushTemplate(MapData(dataMap))
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationChannelId = notificationManager.createNotificationChannelIfRequired(context, template)
+        val notificationChannel = notificationManager.getNotificationChannel(notificationChannelId)
+
+        assertEquals(notificationChannel.sound, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
+    }
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationManagerExtensionsTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationManagerExtensionsTest.kt
@@ -87,4 +87,14 @@ class NotificationManagerExtensionsTest {
 
         assertEquals(notificationChannel.sound, RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
     }
+
+    @Test
+    fun `createNotificationChannelIfRequired should create a silent notification channel when template is created from intent`() {
+        val template = provideMockedBasicPushTemplateWithRequiredData(true)
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationChannelId = notificationManager.createNotificationChannelIfRequired(context, template)
+
+        assertEquals(PushTemplateConstants.DefaultValues.SILENT_NOTIFICATION_CHANNEL_ID, notificationChannelId)
+    }
 }

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
@@ -44,7 +44,7 @@ const val MOCKED_MALFORMED_JSON_ACTION_BUTTON = "[" +
     "{}," +
     "{\"label\":\"Open the app\",\"uri\":\"\",\"type\":\"GO_TO_WEB_PAGE\"}," +
     "{\"label\":\"Go to chess.com\",\"uri\":\"https://chess.com/games/552\",\"type\":\"DEEPLINK\"}]"
-const val MOCKED_CHANNEL_ID = "AEPSDKPushChannel"
+const val MOCKED_CHANNEL_ID = "AEPSDKPushChannel1"
 
 fun <K, V> MutableMap<K, V>.removeKeysFromMap(listOfKeys: List<K>) {
     for (key in listOfKeys) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
MOB-21015: Add unit tests for NotificationManagerExtensions

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[MOB-21015: [Android] Add unit tests for NotificationManagerExtensions](https://jira.corp.adobe.com/browse/MOB-21015)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Increase unit test coverage

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1267" alt="Screenshot 2024-06-06 at 8 12 12 PM" src="https://github.com/adobe/aepsdk-ui-android/assets/169383978/d9f186d8-6232-4075-bdc4-8921b0ad42b1">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
