### PR TITLE
MOB-20954: Add unit tests for InputBoxNotificationBuilder

### DIFF
--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/InputBoxNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/InputBoxNotificationBuilderTest.kt
@@ -17,11 +17,17 @@ import android.content.Context
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
 import com.adobe.marketing.mobile.notificationbuilder.internal.templates.InputBoxPushTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_BODY
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_FEEDBACK_IMAGE
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_FEEDBACK_TEXT
 import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_HINT
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_RECEIVER_NAME
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_TITLE
 import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MockInputBoxPushTemplateDataProvider
 import com.adobe.marketing.mobile.notificationbuilder.internal.templates.provideMockedInputBoxPushTemplateWithRequiredData
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.removeKeysFromMap
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.replaceValueInMap
 import com.adobe.marketing.mobile.notificationbuilder.internal.util.MapData
-import junit.framework.TestCase
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -61,8 +67,9 @@ class InputBoxNotificationBuilderTest {
             trackerActivityClass,
             broadcastReceiverClass
         )
-        TestCase.assertEquals(NotificationCompat.Builder::class.java, notificationBuilder.javaClass)
+
         assertNotNull(notificationBuilder)
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder.javaClass)
     }
 
     @Test
@@ -75,6 +82,7 @@ class InputBoxNotificationBuilderTest {
             broadcastReceiverClass
         )
 
+        assertNotNull(notificationBuilder)
         assertEquals(0, notificationBuilder.mActions.size)
     }
 
@@ -88,8 +96,9 @@ class InputBoxNotificationBuilderTest {
             broadcastReceiverClass
         )
 
-        assertEquals(1, notificationBuilder.mActions.size)
         assertNotNull(notificationBuilder)
+        assertEquals(1, notificationBuilder.mActions.size)
+        assertNotNull(notificationBuilder.mActions.find { it.title == MOCKED_HINT })
     }
 
     @Test
@@ -112,7 +121,7 @@ class InputBoxNotificationBuilderTest {
     }
 
     @Test
-    fun `createInputReceivedPendingIntent should set class when trackerActivityClass parameter is null`() {
+    fun `createInputReceivedPendingIntent should set class when trackerActivityClass parameter is not null`() {
         val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
         val notificationBuilder = InputBoxNotificationBuilder.construct(
             context,
@@ -131,9 +140,33 @@ class InputBoxNotificationBuilderTest {
     }
 
     @Test
+    fun `createInputReceivedPendingIntent should set intent extras correctly`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        val notification = notificationBuilder.build()
+        val pendingIntent = notification.contentIntent
+        val shadowPendingIntent = Shadows.shadowOf(pendingIntent)
+        val intent = shadowPendingIntent.savedIntent
+
+        assertNotNull(intent)
+        assertEquals(MOCKED_TITLE, intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.TITLE))
+        assertEquals(MOCKED_BODY, intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.BODY))
+        assertEquals(MOCKED_RECEIVER_NAME, intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_RECEIVER_NAME))
+        assertEquals(MOCKED_FEEDBACK_IMAGE, intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE))
+        assertEquals(MOCKED_FEEDBACK_TEXT, intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT))
+        assertEquals(MOCKED_HINT, intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT))
+    }
+
+    @Test
     fun `Action with default hint text should be created when inputTextHint field is empty`() {
         val dataMap = MockInputBoxPushTemplateDataProvider.getMockedInputBoxDataMapWithRequiredData()
-        dataMap[PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT] = ""
+        dataMap.replaceValueInMap(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT, "")
 
         val pushTemplate = InputBoxPushTemplate(MapData(dataMap))
         val notificationBuilder = InputBoxNotificationBuilder.construct(
@@ -142,6 +175,8 @@ class InputBoxNotificationBuilderTest {
             trackerActivityClass,
             broadcastReceiverClass
         )
+
+        assertNotNull(notificationBuilder)
 
         val actions = notificationBuilder.mActions
         assertEquals(PushTemplateConstants.DefaultValues.INPUT_BOX_DEFAULT_REPLY_TEXT, actions[0].title)
@@ -150,7 +185,7 @@ class InputBoxNotificationBuilderTest {
     @Test
     fun `Action with default hint text should be created when inputTextHint field is null`() {
         val dataMap = MockInputBoxPushTemplateDataProvider.getMockedInputBoxDataMapWithRequiredData()
-        dataMap.remove(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT)
+        dataMap.removeKeysFromMap(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT)
 
         val pushTemplate = InputBoxPushTemplate(MapData(dataMap))
         val notificationBuilder = InputBoxNotificationBuilder.construct(
@@ -159,6 +194,8 @@ class InputBoxNotificationBuilderTest {
             trackerActivityClass,
             broadcastReceiverClass
         )
+
+        assertNotNull(notificationBuilder)
 
         val actions = notificationBuilder.mActions
         assertEquals(PushTemplateConstants.DefaultValues.INPUT_BOX_DEFAULT_REPLY_TEXT, actions[0].title)
@@ -173,6 +210,8 @@ class InputBoxNotificationBuilderTest {
             trackerActivityClass,
             broadcastReceiverClass
         )
+
+        assertNotNull(notificationBuilder)
 
         val actions = notificationBuilder.mActions
         assertEquals(MOCKED_HINT, actions[0].title)

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/InputBoxNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/InputBoxNotificationBuilderTest.kt
@@ -1,0 +1,180 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.builders
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.InputBoxPushTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MOCKED_HINT
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MockInputBoxPushTemplateDataProvider
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.provideMockedInputBoxPushTemplateWithRequiredData
+import com.adobe.marketing.mobile.notificationbuilder.internal.util.MapData
+import junit.framework.TestCase
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [31])
+class InputBoxNotificationBuilderTest {
+    @Mock
+    private lateinit var context: Context
+    private lateinit var trackerActivityClass: Class<out Activity>
+    private lateinit var broadcastReceiverClass: Class<out BroadcastReceiver>
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        context = RuntimeEnvironment.getApplication()
+        trackerActivityClass = DummyActivity::class.java
+        broadcastReceiverClass = DummyBroadcastReceiver::class.java
+    }
+
+    @Test
+    fun `construct should return a NotificationCompat Builder`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+        TestCase.assertEquals(NotificationCompat.Builder::class.java, notificationBuilder.javaClass)
+        assertNotNull(notificationBuilder)
+    }
+
+    @Test
+    fun `construct should not have any inputText action if the template is created from intent`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData(true)
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        assertEquals(0, notificationBuilder.mActions.size)
+    }
+
+    @Test
+    fun `construct should have an InputText action if the template is not created from intent`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        assertEquals(1, notificationBuilder.mActions.size)
+        assertNotNull(notificationBuilder)
+    }
+
+    @Test
+    fun `createInputReceivedPendingIntent should not set class when trackerActivityClass parameter is null`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            null,
+            broadcastReceiverClass
+        )
+
+        val notification = notificationBuilder.build()
+        val pendingIntent = notification.contentIntent
+        val shadowPendingIntent = Shadows.shadowOf(pendingIntent)
+        val intent = shadowPendingIntent.savedIntent
+
+        assertNotNull(intent)
+        assertNull(intent.resolveActivity(context.packageManager))
+    }
+
+    @Test
+    fun `createInputReceivedPendingIntent should set class when trackerActivityClass parameter is null`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        val notification = notificationBuilder.build()
+        val pendingIntent = notification.contentIntent
+        val shadowPendingIntent = Shadows.shadowOf(pendingIntent)
+        val intent = shadowPendingIntent.savedIntent
+
+        assertNotNull(intent)
+        assertEquals("com.adobe.marketing.mobile.notificationbuilder.internal.builders.DummyActivity", intent.resolveActivity(context.packageManager).className)
+    }
+
+    @Test
+    fun `Action with default hint text should be created when inputTextHint field is empty`() {
+        val dataMap = MockInputBoxPushTemplateDataProvider.getMockedInputBoxDataMapWithRequiredData()
+        dataMap[PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT] = ""
+
+        val pushTemplate = InputBoxPushTemplate(MapData(dataMap))
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        val actions = notificationBuilder.mActions
+        assertEquals(PushTemplateConstants.DefaultValues.INPUT_BOX_DEFAULT_REPLY_TEXT, actions[0].title)
+    }
+
+    @Test
+    fun `Action with default hint text should be created when inputTextHint field is null`() {
+        val dataMap = MockInputBoxPushTemplateDataProvider.getMockedInputBoxDataMapWithRequiredData()
+        dataMap.remove(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT)
+
+        val pushTemplate = InputBoxPushTemplate(MapData(dataMap))
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        val actions = notificationBuilder.mActions
+        assertEquals(PushTemplateConstants.DefaultValues.INPUT_BOX_DEFAULT_REPLY_TEXT, actions[0].title)
+    }
+
+    @Test
+    fun `Action with provided hint text should be created when inputTextHint field is present`() {
+        val pushTemplate = provideMockedInputBoxPushTemplateWithRequiredData()
+        val notificationBuilder = InputBoxNotificationBuilder.construct(
+            context,
+            pushTemplate,
+            trackerActivityClass,
+            broadcastReceiverClass
+        )
+
+        val actions = notificationBuilder.mActions
+        assertEquals(MOCKED_HINT, actions[0].title)
+    }
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
@@ -45,6 +45,10 @@ const val MOCKED_MALFORMED_JSON_ACTION_BUTTON = "[" +
     "{\"label\":\"Open the app\",\"uri\":\"\",\"type\":\"GO_TO_WEB_PAGE\"}," +
     "{\"label\":\"Go to chess.com\",\"uri\":\"https://chess.com/games/552\",\"type\":\"DEEPLINK\"}]"
 const val MOCKED_CHANNEL_ID = "AEPSDKPushChannel1"
+const val MOCKED_RECEIVER_NAME = "receiverName"
+const val MOCKED_HINT = "hint"
+const val MOCKED_FEEDBACK_TEXT = "feedbackText"
+const val MOCKED_FEEDBACK_IMAGE = "https://i.imgur.com/7ZolaOv.jpeg"
 
 fun <K, V> MutableMap<K, V>.removeKeysFromMap(listOfKeys: List<K>) {
     for (key in listOfKeys) {
@@ -115,4 +119,26 @@ internal fun provideMockedAutoCarousalTemplate(isFromIntent: Boolean = false): A
         data = MapData(dataMap)
     }
     return CarouselPushTemplate(data) as AutoCarouselPushTemplate
+}
+
+internal fun provideMockedInputBoxPushTemplateWithAllKeys(isFromIntent: Boolean = false): InputBoxPushTemplate {
+    val data: NotificationData = if (isFromIntent) {
+        val mockBundle = MockInputBoxPushTemplateDataProvider.getMockedInputBoxBundleWithAllKeys()
+        IntentData(mockBundle, null)
+    } else {
+        val dataMap = MockInputBoxPushTemplateDataProvider.getMockedInputBoxDataMapWithAllKeys()
+        MapData(dataMap)
+    }
+    return InputBoxPushTemplate(data)
+}
+
+internal fun provideMockedInputBoxPushTemplateWithRequiredData(isFromIntent: Boolean = false): InputBoxPushTemplate {
+    val data: NotificationData = if (isFromIntent) {
+        val mockBundle = MockInputBoxPushTemplateDataProvider.getMockedInputBoxBundleWithRequiredData()
+        IntentData(mockBundle, null)
+    } else {
+        val dataMap = MockInputBoxPushTemplateDataProvider.getMockedInputBoxDataMapWithRequiredData()
+        MapData(dataMap)
+    }
+    return InputBoxPushTemplate(data)
 }

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockInputBoxPushTemplateDataProvider.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockInputBoxPushTemplateDataProvider.kt
@@ -1,0 +1,113 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.templates
+
+import android.os.Bundle
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateType
+
+object MockInputBoxPushTemplateDataProvider {
+    fun getMockedInputBoxDataMapWithRequiredData(): MutableMap<String, String> {
+        return mutableMapOf(
+            PushTemplateConstants.PushPayloadKeys.TITLE to MOCKED_TITLE,
+            PushTemplateConstants.PushPayloadKeys.BODY to MOCKED_BODY,
+            PushTemplateConstants.PushPayloadKeys.VERSION to MOCKED_PAYLOAD_VERSION,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_RECEIVER_NAME to MOCKED_RECEIVER_NAME,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT to MOCKED_HINT,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT to MOCKED_FEEDBACK_TEXT,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE to MOCKED_FEEDBACK_IMAGE
+        )
+    }
+
+    fun getMockedInputBoxBundleWithRequiredData(): Bundle {
+        val mockBundle = Bundle()
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE, MOCKED_TITLE)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY, MOCKED_BODY)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VERSION, MOCKED_PAYLOAD_VERSION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_RECEIVER_NAME, MOCKED_RECEIVER_NAME)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT, MOCKED_HINT)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT, MOCKED_FEEDBACK_TEXT)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE, MOCKED_FEEDBACK_IMAGE)
+        return mockBundle
+    }
+
+    fun getMockedInputBoxDataMapWithAllKeys(): MutableMap<String, String> {
+        return mutableMapOf(
+            PushTemplateConstants.PushPayloadKeys.TAG to MOCKED_TAG,
+            PushTemplateConstants.PushPayloadKeys.TITLE to MOCKED_TITLE,
+            PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE to PushTemplateType.BASIC.value,
+            PushTemplateConstants.PushPayloadKeys.ACTION_URI to MOCKED_ACTION_URI,
+            PushTemplateConstants.PushPayloadKeys.ACTION_TYPE to PushTemplateConstants.ActionType.NONE.name,
+            PushTemplateConstants.PushPayloadKeys.ACTION_BUTTONS to MOCKED_ACTION_BUTTON_DATA,
+            PushTemplateConstants.PushPayloadKeys.BADGE_COUNT to "5",
+            PushTemplateConstants.PushPayloadKeys.BODY to MOCKED_BASIC_TEMPLATE_BODY,
+            PushTemplateConstants.PushPayloadKeys.CHANNEL_ID to MOCKED_CHANNEL_ID,
+            PushTemplateConstants.PushPayloadKeys.EXPANDED_BODY_TEXT to MOCKED_BASIC_TEMPLATE_BODY_EXPANDED,
+            PushTemplateConstants.PushPayloadKeys.BODY_TEXT_COLOR to "FFD966",
+            PushTemplateConstants.PushPayloadKeys.IMAGE_URL to MOCKED_IMAGE_URI,
+            PushTemplateConstants.PushPayloadKeys.LARGE_ICON to MOCKED_LARGE_ICON,
+            PushTemplateConstants.PushPayloadKeys.BACKGROUND_COLOR to "FFD966",
+            PushTemplateConstants.PushPayloadKeys.PRIORITY to MOCKED_PRIORITY,
+            PushTemplateConstants.PushPayloadKeys.VISIBILITY to MOCKED_VISIBILITY,
+            PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TEXT to MOCK_REMIND_LATER_TEXT,
+            PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TIMESTAMP to MOCK_REMIND_LATER_TIME,
+            PushTemplateConstants.PushPayloadKeys.REMIND_LATER_DURATION to MOCK_REMIND_LATER_DURATION,
+            PushTemplateConstants.PushPayloadKeys.SOUND to "bell",
+            PushTemplateConstants.PushPayloadKeys.SMALL_ICON to MOCKED_SMALL_ICON,
+            PushTemplateConstants.PushPayloadKeys.TITLE_TEXT_COLOR to "FFD966",
+            PushTemplateConstants.PushPayloadKeys.TICKER to MOCKED_TICKER,
+            PushTemplateConstants.PushPayloadKeys.VERSION to MOCKED_PAYLOAD_VERSION,
+            PushTemplateConstants.PushPayloadKeys.STICKY to "true",
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_RECEIVER_NAME to MOCKED_RECEIVER_NAME,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT to MOCKED_HINT,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT to MOCKED_FEEDBACK_TEXT,
+            PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE to MOCKED_FEEDBACK_IMAGE
+        )
+    }
+
+    fun getMockedInputBoxBundleWithAllKeys(): Bundle {
+        val mockBundle = Bundle()
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VERSION, MOCKED_PAYLOAD_VERSION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE, MOCKED_TITLE)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY, MOCKED_BODY)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TAG, MOCKED_TAG)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE, MOCKED_TITLE)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE, PushTemplateType.BASIC.value)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_URI, MOCKED_ACTION_URI)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_TYPE, PushTemplateConstants.ActionType.NONE.name)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_BUTTONS, MOCKED_ACTION_BUTTON_DATA)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BADGE_COUNT, "5")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY, MOCKED_BASIC_TEMPLATE_BODY)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CHANNEL_ID, "2024")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.EXPANDED_BODY_TEXT, MOCKED_BASIC_TEMPLATE_BODY_EXPANDED)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY_TEXT_COLOR, "FFD966")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.IMAGE_URL, MOCKED_IMAGE_URI)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.LARGE_ICON, MOCKED_LARGE_ICON)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BACKGROUND_COLOR, "FFD966")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.PRIORITY, (MOCKED_PRIORITY))
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VISIBILITY, MOCKED_VISIBILITY)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TEXT, MOCK_REMIND_LATER_TEXT)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TIMESTAMP, MOCK_REMIND_LATER_TIME)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.REMIND_LATER_DURATION, MOCK_REMIND_LATER_DURATION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.SOUND, "bell")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.SMALL_ICON, MOCKED_SMALL_ICON)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE_TEXT_COLOR, "FFD966")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TICKER, MOCKED_TICKER)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VERSION, MOCKED_PAYLOAD_VERSION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.STICKY, "true")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_RECEIVER_NAME, MOCKED_RECEIVER_NAME)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_HINT, MOCKED_HINT)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_TEXT, MOCKED_FEEDBACK_TEXT)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.INPUT_BOX_FEEDBACK_IMAGE, MOCKED_FEEDBACK_IMAGE)
+        return mockBundle
+    }
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockInputBoxPushTemplateDataProvider.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockInputBoxPushTemplateDataProvider.kt
@@ -45,9 +45,6 @@ object MockInputBoxPushTemplateDataProvider {
             PushTemplateConstants.PushPayloadKeys.TAG to MOCKED_TAG,
             PushTemplateConstants.PushPayloadKeys.TITLE to MOCKED_TITLE,
             PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE to PushTemplateType.BASIC.value,
-            PushTemplateConstants.PushPayloadKeys.ACTION_URI to MOCKED_ACTION_URI,
-            PushTemplateConstants.PushPayloadKeys.ACTION_TYPE to PushTemplateConstants.ActionType.NONE.name,
-            PushTemplateConstants.PushPayloadKeys.ACTION_BUTTONS to MOCKED_ACTION_BUTTON_DATA,
             PushTemplateConstants.PushPayloadKeys.BADGE_COUNT to "5",
             PushTemplateConstants.PushPayloadKeys.BODY to MOCKED_BASIC_TEMPLATE_BODY,
             PushTemplateConstants.PushPayloadKeys.CHANNEL_ID to MOCKED_CHANNEL_ID,
@@ -58,9 +55,6 @@ object MockInputBoxPushTemplateDataProvider {
             PushTemplateConstants.PushPayloadKeys.BACKGROUND_COLOR to "FFD966",
             PushTemplateConstants.PushPayloadKeys.PRIORITY to MOCKED_PRIORITY,
             PushTemplateConstants.PushPayloadKeys.VISIBILITY to MOCKED_VISIBILITY,
-            PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TEXT to MOCK_REMIND_LATER_TEXT,
-            PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TIMESTAMP to MOCK_REMIND_LATER_TIME,
-            PushTemplateConstants.PushPayloadKeys.REMIND_LATER_DURATION to MOCK_REMIND_LATER_DURATION,
             PushTemplateConstants.PushPayloadKeys.SOUND to "bell",
             PushTemplateConstants.PushPayloadKeys.SMALL_ICON to MOCKED_SMALL_ICON,
             PushTemplateConstants.PushPayloadKeys.TITLE_TEXT_COLOR to "FFD966",
@@ -82,9 +76,6 @@ object MockInputBoxPushTemplateDataProvider {
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TAG, MOCKED_TAG)
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE, MOCKED_TITLE)
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE, PushTemplateType.BASIC.value)
-        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_URI, MOCKED_ACTION_URI)
-        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_TYPE, PushTemplateConstants.ActionType.NONE.name)
-        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_BUTTONS, MOCKED_ACTION_BUTTON_DATA)
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BADGE_COUNT, "5")
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY, MOCKED_BASIC_TEMPLATE_BODY)
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CHANNEL_ID, "2024")
@@ -95,9 +86,6 @@ object MockInputBoxPushTemplateDataProvider {
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BACKGROUND_COLOR, "FFD966")
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.PRIORITY, (MOCKED_PRIORITY))
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VISIBILITY, MOCKED_VISIBILITY)
-        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TEXT, MOCK_REMIND_LATER_TEXT)
-        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.REMIND_LATER_TIMESTAMP, MOCK_REMIND_LATER_TIME)
-        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.REMIND_LATER_DURATION, MOCK_REMIND_LATER_DURATION)
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.SOUND, "bell")
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.SMALL_ICON, MOCKED_SMALL_ICON)
         mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE_TEXT_COLOR, "FFD966")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
MOB-20954: Add unit tests for InputBoxNotificationBuilder

<!--- Describe your changes in detail -->
- Added unit tests
- Added data provider utility classes for InputBoxPushTemplate

## Related Issue
[MOB-20954: [Android] Add unit tests for InputBoxNotificationBuilder](https://jira.corp.adobe.com/browse/MOB-20954)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1339" alt="Screenshot 2024-06-10 at 5 04 04 PM" src="https://github.com/adobe/aepsdk-ui-android/assets/169383978/284159c4-43d2-46da-97c5-01c918c454d3">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
