### PR TITLE
MOB-21188: [Android] Add unit tests for ProductCatalogNotificationBuilder

### DIFF
--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilderTest.kt
@@ -1,0 +1,147 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.builders
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.core.app.NotificationCompat
+import com.adobe.marketing.mobile.notificationbuilder.NotificationConstructionFailedException
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants.DefaultValues.PRODUCT_CATALOG_VERTICAL_LAYOUT
+import com.adobe.marketing.mobile.notificationbuilder.R
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateImageUtils
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateImageUtils.cacheImages
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateImageUtils.getCachedImage
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MockProductCatalogTemplateDataProvider.getMockedMapWithProductCatalogData
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.ProductCatalogPushTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.provideMockedProductCatalogTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.replaceValueInMap
+import com.adobe.marketing.mobile.notificationbuilder.internal.util.MapData
+import io.mockk.every
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [31])
+class ProductCatalogNotificationBuilderTest {
+    @Mock
+    private lateinit var context: Context
+    private lateinit var trackerActivityClass: Class<out Activity>
+    private lateinit var broadcastReceiverClass: Class<out BroadcastReceiver>
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        context = RuntimeEnvironment.getApplication()
+        trackerActivityClass = DummyActivity::class.java
+        broadcastReceiverClass = DummyBroadcastReceiver::class.java
+        mockkObject(PushTemplateImageUtils)
+    }
+
+    @Test
+    fun `construct should throw NotificationConstructionFailedException if downloaded image count does not match catalog image count`() {
+        val pushTemplate = provideMockedProductCatalogTemplate()
+
+        assertFailsWith(
+            exceptionClass = NotificationConstructionFailedException::class,
+            message = "Failed to download all images for the product catalog notification.",
+            block = {
+                ProductCatalogNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+            }
+        )
+    }
+
+    @Test
+    fun `construct should return a NotificationCompat Builder if download image count matches catalog image count`() {
+        val pushTemplate = provideMockedProductCatalogTemplate()
+        val cachedItem = mockkClass(Bitmap::class)
+
+        // product catalog template requires 3 catalog items
+        every { cacheImages(any()) } answers { 3 }
+        every { getCachedImage(any()) } answers { cachedItem }
+        val notificationBuilder = ProductCatalogNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        assertEquals(R.layout.push_template_horizontal_catalog, notificationBuilder.bigContentView.layoutId)
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+
+    @Test
+    fun `construct should build a notification with a vertical layout if vertical layout is provided`() {
+        val dataMap = getMockedMapWithProductCatalogData()
+        dataMap.replaceValueInMap(PushTemplateConstants.PushPayloadKeys.CATALOG_LAYOUT, PRODUCT_CATALOG_VERTICAL_LAYOUT)
+        val pushTemplate = ProductCatalogPushTemplate(MapData(dataMap))
+        val cachedItem = mockkClass(Bitmap::class)
+
+        // product catalog template requires 3 catalog items
+        every { cacheImages(any()) } answers { 3 }
+        every { getCachedImage(any()) } answers { cachedItem }
+
+        val notificationBuilder = ProductCatalogNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+        assertEquals(R.layout.push_tempate_vertical_catalog, notificationBuilder.bigContentView.layoutId)
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+
+    @Test
+    fun `construct should return a valid NotificationCompat Builder Broadcast Receiver is not provided`() {
+        val pushTemplate = provideMockedProductCatalogTemplate()
+        val cachedItem = mockkClass(Bitmap::class)
+
+        // product catalog template requires 3 catalog items
+        every { cacheImages(any()) } answers { 3 }
+        every { getCachedImage(any()) } answers { cachedItem }
+
+        val notificationBuilder = ProductCatalogNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, null)
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+
+    @Test
+    fun `construct should throw NotificationConstructionFailedException if catalog thumbnail is not found`() {
+        val pushTemplate = provideMockedProductCatalogTemplate()
+        every { cacheImages(any()) } answers { 3 }
+
+        assertFailsWith(
+            exceptionClass = NotificationConstructionFailedException::class,
+            message = "No image found for catalog item thumbnail.",
+            block = {
+                ProductCatalogNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+            }
+        )
+    }
+
+    @Test
+    fun `construct should return a NotificationCompat Builder if Tag is provided in Push Template`() {
+        val dataMap = getMockedMapWithProductCatalogData()
+        dataMap[PushTemplateConstants.PushPayloadKeys.TAG] = "tag"
+        val pushTemplate = ProductCatalogPushTemplate(MapData(dataMap))
+        val cachedItem = mockkClass(Bitmap::class)
+
+        // product catalog template requires 3 catalog items
+        every { cacheImages(any()) } answers { 3 }
+        every { getCachedImage(any()) } answers { cachedItem }
+
+        val notificationBuilder = ProductCatalogNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
@@ -150,3 +150,14 @@ internal fun provideMockedMultiIconTemplateWithAllKeys(): MultiIconPushTemplate 
     data = MapData(dataMap)
     return MultiIconPushTemplate(data)
 }
+
+internal fun provideMockedProductCatalogTemplate(isFromIntent: Boolean = false): ProductCatalogPushTemplate {
+    val data: NotificationData
+    if (isFromIntent) {
+        val mockBundle = MockProductCatalogTemplateDataProvider.getMockedBundleWithProductCatalogData()
+        data = IntentData(mockBundle, null)
+    } else {
+        data = MapData(MockProductCatalogTemplateDataProvider.getMockedMapWithProductCatalogData())
+    }
+    return ProductCatalogPushTemplate(data)
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockProductCatalogTemplateDataProvider.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockProductCatalogTemplateDataProvider.kt
@@ -1,0 +1,56 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.templates
+
+import android.os.Bundle
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+
+object MockProductCatalogTemplateDataProvider {
+    fun getMockedMapWithProductCatalogData(): MutableMap<String, String> {
+        return mutableMapOf(
+            PushTemplateConstants.PushPayloadKeys.TITLE to MOCKED_TITLE,
+            PushTemplateConstants.PushPayloadKeys.BODY to MOCKED_BODY,
+            PushTemplateConstants.PushPayloadKeys.VERSION to MOCKED_PAYLOAD_VERSION,
+            PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_TEXT to "ctaButtonText",
+            PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_COLOR to "ctaButtonColor",
+            PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_TEXT_COLOR to "ctaButtonTextColor",
+            PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_URI to "ctaButtonUri",
+            PushTemplateConstants.PushPayloadKeys.CATALOG_LAYOUT to "horizontal",
+            PushTemplateConstants.PushPayloadKeys.CATALOG_ITEMS to "[" +
+                "{\"title\":\"title1\",\"body\":\"body1\",\"img\":\"https://images.pexels.com/photos/260024/pexels-photo-260024.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2\",\"price\":\"price1\",\"uri\":\"uri1\"}," +
+                "{\"title\":\"title2\",\"body\":\"body2\",\"img\":\"https://images.pexels.com/photos/260024/pexels-photo-260024.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2\",\"price\":\"price2\",\"uri\":\"uri2\"}," +
+                "{\"title\":\"title3\",\"body\":\"body3\",\"img\":\"https://images.pexels.com/photos/260024/pexels-photo-260024.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2\",\"price\":\"price3\",\"uri\":\"uri3\"}" +
+                "]"
+        )
+    }
+
+    fun getMockedBundleWithProductCatalogData(): Bundle {
+        val mockBundle = Bundle()
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE, MOCKED_TITLE)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY, MOCKED_BODY)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VERSION, MOCKED_PAYLOAD_VERSION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_TEXT, "ctaButtonText")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_COLOR, "ctaButtonColor")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_TEXT_COLOR, "ctaButtonTextColor")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CATALOG_CTA_BUTTON_URI, "ctaButtonUri")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.CATALOG_LAYOUT, "horizontal")
+        mockBundle.putString(
+            PushTemplateConstants.PushPayloadKeys.CATALOG_ITEMS,
+            "[" +
+                "{\"title\":\"title1\",\"body\":\"body1\",\"img\":\"https://images.pexels.com/photos/260024/pexels-photo-260024.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2\",\"price\":\"price1\",\"uri\":\"uri1\"}," +
+                "{\"title\":\"title2\",\"body\":\"body2\",\"img\":\"https://images.pexels.com/photos/260024/pexels-photo-260024.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2\",\"price\":\"price2\",\"uri\":\"uri2\"}," +
+                "{\"title\":\"title3\",\"body\":\"body3\",\"img\":\"https://images.pexels.com/photos/260024/pexels-photo-260024.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2\",\"price\":\"price3\",\"uri\":\"uri3\"}" +
+                "]"
+        )
+        return mockBundle
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add unit  tests for ProductCatalogNotificationBuilder

<!--- Describe your changes in detail -->

## Related Issue
[MOB-21188:](https://jira.corp.adobe.com/browse/MOB-21188) [Android] Add unit tests for ProductCatalogNotificationBuilder

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1342" alt="Screenshot 2024-06-20 at 2 25 39 PM" src="https://github.com/adobe/aepsdk-ui-android/assets/169383978/4f037753-7fe2-49ca-9ebe-6ab28ba5c108">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
