### PR TITLE
MOB-21194: Add unit tests for ProductRatingNotificationBuilder

### DIFF
--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilderTest.kt
@@ -1,0 +1,190 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.builders
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.graphics.Bitmap
+import android.view.View
+import android.widget.RemoteViews
+import androidx.core.app.NotificationCompat
+import com.adobe.marketing.mobile.notificationbuilder.NotificationConstructionFailedException
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.adobe.marketing.mobile.notificationbuilder.R
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateImageUtils
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateImageUtils.cacheImages
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateImageUtils.getCachedImage
+import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setRemoteViewClickAction
+import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setRemoteViewImage
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MockProductRatingTemplateDataProvider.getMockedDataMapForRatingTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.ProductRatingPushTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.templates.provideMockedProductRatingTemplate
+import com.adobe.marketing.mobile.notificationbuilder.internal.util.MapData
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkClass
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [31])
+class ProductRatingNotificationBuilderTest {
+    private lateinit var context: Context
+    private lateinit var trackerActivityClass: Class<out Activity>
+    private lateinit var broadcastReceiverClass: Class<out BroadcastReceiver>
+
+    @Before
+    fun setUp() {
+//        MockitoAnnotations.openMocks(this)
+
+        context = RuntimeEnvironment.getApplication()
+        trackerActivityClass = DummyActivity::class.java
+        broadcastReceiverClass = DummyBroadcastReceiver::class.java
+        mockkConstructor(RemoteViews::class)
+        mockkStatic(RemoteViews::setRemoteViewImage)
+        mockkStatic(RemoteViews::setRemoteViewClickAction)
+        mockkObject(PushTemplateImageUtils)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `construct should return a NotificationCompat Builder`() {
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+
+        val pushTemplate = provideMockedProductRatingTemplate()
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+
+    @Test
+    fun `construct should set visibility of expanded layout as GONE if no images are downloaded`() {
+        every { cacheImages(any()) } answers { 0 }
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+        every { anyConstructed<RemoteViews>().setViewVisibility(any(), View.GONE) } just Runs
+
+        val pushTemplate = provideMockedProductRatingTemplate()
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        verify(exactly = 1) { anyConstructed<RemoteViews>().setViewVisibility(R.id.expanded_template_image, View.GONE) }
+    }
+
+    @Test
+    fun `construct should set image for expanded layout if image is downloaded successfully`() {
+        val cachedItem = mockkClass(Bitmap::class)
+
+        every { cacheImages(any()) } answers { 1 }
+        every { getCachedImage(any()) } answers { cachedItem }
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+        every { anyConstructed<RemoteViews>().setViewVisibility(any(), View.GONE) } just Runs
+
+        val pushTemplate = provideMockedProductRatingTemplate()
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        verify(exactly = 1) { anyConstructed<RemoteViews>().setImageViewBitmap(R.id.expanded_template_image, any()) }
+    }
+
+    @Test
+    fun `Rating Confirmation action should be hidden if no rating has been selected`() {
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+        every { anyConstructed<RemoteViews>().setViewVisibility(any(), any()) } just Runs
+
+        val pushTemplate = provideMockedProductRatingTemplate()
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        verify(exactly = 1) { anyConstructed<RemoteViews>().setViewVisibility(R.id.rating_confirm, View.INVISIBLE) }
+    }
+
+    @Test
+    fun `Rating confirmation action should be visible when rating is selected`() {
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+        every { anyConstructed<RemoteViews>().setViewVisibility(any(), any()) } just Runs
+
+        val dataMap = getMockedDataMapForRatingTemplate()
+        dataMap[PushTemplateConstants.IntentKeys.RATING_SELECTED] = "3"
+        val pushTemplate = ProductRatingPushTemplate(MapData(dataMap))
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        verify(exactly = 1) { anyConstructed<RemoteViews>().setViewVisibility(R.id.rating_confirm, View.VISIBLE) }
+    }
+
+    @Test
+    fun `construct should throw NotificationConstructionFailedException if image for unselected rating icon is invalid`() {
+        val pushTemplate = provideMockedProductRatingTemplate()
+
+        assertFailsWith(
+            exceptionClass = NotificationConstructionFailedException::class,
+            message = "Image for unselected rating icon is invalid.",
+            block = {
+                ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+            }
+        )
+    }
+
+    @Test
+    fun `construct should throw NotificationConstructionFailedException if image for selected rating icon is invalid`() {
+        every { any<RemoteViews>().setRemoteViewImage("rating_star_outline", any()) } returns true
+        every { any<RemoteViews>().setRemoteViewImage("rating_star_filled", any()) } returns false
+
+        val dataMap = getMockedDataMapForRatingTemplate()
+        dataMap[PushTemplateConstants.IntentKeys.RATING_SELECTED] = "3"
+        val pushTemplate = ProductRatingPushTemplate(MapData(dataMap))
+
+        assertFailsWith(
+            exceptionClass = NotificationConstructionFailedException::class,
+            message = "Image for selected rating icon is invalid.",
+            block = {
+                ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+            }
+        )
+    }
+
+    @Test
+    fun `construct should return a valid NotificationCompat Builder if Broadcast Receiver is not provided`() {
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+
+        val pushTemplate = provideMockedProductRatingTemplate()
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, null)
+
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+
+    @Test
+    fun `construct should return a NotificationCompat Builder if Tag is provided in Push Template`() {
+        every { any<RemoteViews>().setRemoteViewImage(any(), any()) } returns true
+
+        val dataMap = getMockedDataMapForRatingTemplate()
+        dataMap[PushTemplateConstants.PushPayloadKeys.TAG] = "tag"
+        val pushTemplate = ProductRatingPushTemplate(MapData(dataMap))
+        val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
+
+        assertEquals(NotificationCompat.Builder::class.java, notificationBuilder::class.java)
+    }
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockDataUtils.kt
@@ -150,3 +150,15 @@ internal fun provideMockedMultiIconTemplateWithAllKeys(): MultiIconPushTemplate 
     data = MapData(dataMap)
     return MultiIconPushTemplate(data)
 }
+
+internal fun provideMockedProductRatingTemplate(isFromIntent: Boolean = false): ProductRatingPushTemplate {
+    val data: NotificationData
+    if (isFromIntent) {
+        val mockBundle = MockProductRatingTemplateDataProvider.getMockedBundleForRatingTemplate()
+        data = IntentData(mockBundle, null)
+    } else {
+        val dataMap = MockProductRatingTemplateDataProvider.getMockedDataMapForRatingTemplate()
+        data = MapData(dataMap)
+    }
+    return ProductRatingPushTemplate(data)
+}

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockProductRatingTemplateDataProvider.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/MockProductRatingTemplateDataProvider.kt
@@ -1,0 +1,52 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.notificationbuilder.internal.templates
+
+import android.os.Bundle
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.adobe.marketing.mobile.notificationbuilder.internal.PushTemplateType
+
+object MockProductRatingTemplateDataProvider {
+    fun getMockedDataMapForRatingTemplate(): MutableMap<String, String> {
+        return mutableMapOf(
+            PushTemplateConstants.PushPayloadKeys.VERSION to MOCKED_PAYLOAD_VERSION,
+            PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE to PushTemplateType.PRODUCT_RATING.value,
+            PushTemplateConstants.PushPayloadKeys.TITLE to MOCKED_TITLE,
+            PushTemplateConstants.PushPayloadKeys.BODY to MOCKED_BODY,
+            PushTemplateConstants.PushPayloadKeys.EXPANDED_BODY_TEXT to MOCKED_BASIC_TEMPLATE_BODY_EXPANDED,
+            PushTemplateConstants.PushPayloadKeys.IMAGE_URL to MOCKED_IMAGE_URI,
+            PushTemplateConstants.PushPayloadKeys.ACTION_TYPE to "WEBURL",
+            PushTemplateConstants.PushPayloadKeys.ACTION_URI to MOCKED_ACTION_URI,
+            PushTemplateConstants.PushPayloadKeys.VERSION to MOCKED_PAYLOAD_VERSION,
+            PushTemplateConstants.PushPayloadKeys.RATING_UNSELECTED_ICON to "rating_star_outline",
+            PushTemplateConstants.PushPayloadKeys.RATING_SELECTED_ICON to "rating_star_filled",
+            PushTemplateConstants.PushPayloadKeys.RATING_ACTIONS to "[{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"OPENAPP\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\": \"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"}]"
+        )
+    }
+
+    fun getMockedBundleForRatingTemplate(): Bundle {
+        val mockBundle = Bundle()
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VERSION, MOCKED_PAYLOAD_VERSION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TEMPLATE_TYPE, PushTemplateType.PRODUCT_RATING.value)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.TITLE, MOCKED_TITLE)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.BODY, MOCKED_BODY)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.EXPANDED_BODY_TEXT, MOCKED_BASIC_TEMPLATE_BODY_EXPANDED)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.IMAGE_URL, MOCKED_IMAGE_URI)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_TYPE, "WEBURL")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.ACTION_URI, MOCKED_ACTION_URI)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.VERSION, MOCKED_PAYLOAD_VERSION)
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.RATING_UNSELECTED_ICON, "rating_star_outline")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.RATING_SELECTED_ICON, "rating_star_filled")
+        mockBundle.putString(PushTemplateConstants.PushPayloadKeys.RATING_ACTIONS, "[{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"OPENAPP\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\": \"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"}]")
+        return mockBundle
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add unit tests for ProductRatingNotificationBuilder
<!--- Describe your changes in detail -->

## Related Issue
[MOB-21194](https://jira.corp.adobe.com/browse/MOB-21194): Add unit tests for ProductRatingNotificationBuilder

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1335" alt="Screenshot 2024-06-21 at 1 32 49 AM" src="https://github.com/adobe/aepsdk-ui-android/assets/169383978/c8694432-f49c-4fe8-9c76-0a72c88812b3">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
