### PR TITLE
[MOB-21298] Make some required fields as optional for ICON template

### DIFF
--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/AEPPushTemplate.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/templates/AEPPushTemplate.kt
@@ -29,13 +29,13 @@ import com.adobe.marketing.mobile.notificationbuilder.internal.util.Notification
 internal sealed class AEPPushTemplate(val data: NotificationData) {
 
     // Required, title of the message shown in the collapsed and expanded push template layouts
-    internal val title: String
+    internal lateinit var title: String
 
     // Required, body of the message shown in the collapsed push template layout
-    internal val body: String
+    internal lateinit var body: String
 
     // Required, Version of the payload assigned by the authoring UI.
-    internal val payloadVersion: String
+    internal lateinit var payloadVersion: String
 
     // begin optional values
     // Optional, sound to play when the notification is shown
@@ -107,17 +107,14 @@ internal sealed class AEPPushTemplate(val data: NotificationData) {
      * Initializes the push template with the given NotificationData.
      */
     init {
-        // extract the payload version
-        payloadVersion = data.getRequiredString(PushPayloadKeys.VERSION)
 
-        // extract the remaining text information
-        title = data.getRequiredString(PushPayloadKeys.TITLE)
-        body = data.getRequiredString(PushPayloadKeys.BODY)
+        templateType = PushTemplateType.fromString(data.getString(PushPayloadKeys.TEMPLATE_TYPE))
+        initRequiredValues()
+        // extract the payload version
         expandedBodyText = data.getString(PushPayloadKeys.EXPANDED_BODY_TEXT)
         ticker = data.getString(PushPayloadKeys.TICKER)
 
         // extract the template type
-        templateType = PushTemplateType.fromString(data.getString(PushPayloadKeys.TEMPLATE_TYPE))
         isFromIntent = data is IntentData
 
         // extract the basic media information
@@ -149,6 +146,21 @@ internal sealed class AEPPushTemplate(val data: NotificationData) {
         // extract notification priority and visibility
         priority = NotificationPriority.fromString(data.getString(PushPayloadKeys.PRIORITY))
         visibility = NotificationVisibility.fromString(data.getString(PushPayloadKeys.VISIBILITY))
+    }
+
+    private fun initRequiredValues() {
+
+        payloadVersion = data.getRequiredString(PushPayloadKeys.VERSION)
+
+        // extract the remaining text information
+        if (templateType == PushTemplateType.MULTI_ICON) {
+            // Title and body are not required for FiveIconPushTemplate
+            title = ""
+            body = ""
+        } else {
+            title = data.getRequiredString(PushPayloadKeys.TITLE)
+            body = data.getRequiredString(PushPayloadKeys.BODY)
+        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Making some required fields as optional for Icon templates

## Description
<!--- Describe your changes in detail -->
Five Icon template does not need title and body fields, but they as treated as required field in AEPPushTemplate (Base class) and later in the flow, AEPPushNotificationBuilder.construct method uses the field. So in case of icon template we have made this as empty field.

## Related Issue
https://jira.corp.adobe.com/browse/MOB-21298

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
