### PR TITLE
MOB-21822: Fix dismissed intents

### DIFF
--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX=true
 #Maven artifacts
 #Notification Builder Module
 notificationbuilderModuleName=notificationbuilder
-notificationbuilderVersion=3.0.0
+notificationbuilderVersion=3.0.1
 notificationbuilderMavenRepoName=AdobeMobileNotificationBuilderSdk
 notificationbuilderMavenRepoDescription=Android Notification Builder library for Adobe Mobile Marketing
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX=true
 #Maven artifacts
 #Notification Builder Module
 notificationbuilderModuleName=notificationbuilder
-notificationbuilderVersion=3.0.1
+notificationbuilderVersion=3.0.2
 notificationbuilderMavenRepoName=AdobeMobileNotificationBuilderSdk
 notificationbuilderMavenRepoDescription=Android Notification Builder library for Adobe Mobile Marketing
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
@@ -53,7 +53,7 @@ import com.adobe.marketing.mobile.services.ServiceProvider
  */
 object NotificationBuilder {
     private const val SELF_TAG = "NotificationBuilder"
-    private const val VERSION = "3.0.0"
+    private const val VERSION = "3.0.1"
 
     @JvmStatic
     fun version(): String {

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilder.kt
@@ -53,7 +53,7 @@ import com.adobe.marketing.mobile.services.ServiceProvider
  */
 object NotificationBuilder {
     private const val SELF_TAG = "NotificationBuilder"
-    private const val VERSION = "3.0.1"
+    private const val VERSION = "3.0.2"
 
     @JvmStatic
     fun version(): String {

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
@@ -96,6 +96,7 @@ internal object PendingIntentUtils {
      * notification
      * @param actionUri the action uri
      * @param actionID the action ID
+     * @param actionType the type of the action
      * @param intentExtras the [Bundle] containing the extras to be added to the intent
      * @return the created [PendingIntent]
      */
@@ -104,9 +105,13 @@ internal object PendingIntentUtils {
         trackerActivityClass: Class<out Activity>?,
         actionUri: String?,
         actionID: String?,
+        actionType: String?,
         intentExtras: Bundle?
     ): PendingIntent? {
-        val intent = Intent(PushTemplateConstants.NotificationAction.CLICKED)
+        val intent = if (PushTemplateConstants.ActionType.DISMISS.name == actionType) {
+            Intent(PushTemplateConstants.NotificationAction.DISMISSED)
+        } else Intent(PushTemplateConstants.NotificationAction.CLICKED)
+
         trackerActivityClass?.let {
             intent.setClass(context.applicationContext, trackerActivityClass)
         }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/PendingIntentUtils.kt
@@ -105,10 +105,10 @@ internal object PendingIntentUtils {
         trackerActivityClass: Class<out Activity>?,
         actionUri: String?,
         actionID: String?,
-        actionType: String?,
+        actionType: PushTemplateConstants.ActionType?,
         intentExtras: Bundle?
     ): PendingIntent? {
-        val intent = if (PushTemplateConstants.ActionType.DISMISS.name == actionType) {
+        val intent = if (PushTemplateConstants.ActionType.DISMISS == actionType) {
             Intent(PushTemplateConstants.NotificationAction.DISMISSED)
         } else Intent(PushTemplateConstants.NotificationAction.CLICKED)
 

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AEPPushNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AEPPushNotificationBuilder.kt
@@ -102,6 +102,7 @@ internal object AEPPushNotificationBuilder {
                 context,
                 trackerActivityClass,
                 pushTemplate.actionUri,
+                pushTemplate.actionType,
                 pushTemplate.data.getBundle()
             )
             .setNotificationDeleteAction(context, trackerActivityClass)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilder.kt
@@ -138,6 +138,7 @@ internal object AutoCarouselNotificationBuilder {
                     R.id.carousel_item_image_view,
                     interactionUri,
                     null,
+                    null,
                     pushTemplate.data.getBundle()
                 )
             }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/LegacyNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/LegacyNotificationBuilder.kt
@@ -73,6 +73,7 @@ internal object LegacyNotificationBuilder {
                 context,
                 trackerActivityClass,
                 pushTemplate.actionUri,
+                pushTemplate.actionType,
                 pushTemplate.data.getBundle()
             )
             // set notification delete action

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ManualCarouselNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ManualCarouselNotificationBuilder.kt
@@ -303,6 +303,7 @@ internal object ManualCarouselNotificationBuilder {
                     R.id.carousel_item_image_view,
                     interactionUri,
                     null,
+                    null,
                     pushTemplate.data.getBundle()
                 )
             }
@@ -386,6 +387,7 @@ internal object ManualCarouselNotificationBuilder {
             trackerActivityClass,
             R.id.manual_carousel_filmstrip_center,
             interactionUri,
+            null,
             null,
             pushTemplate.data.getBundle()
         )

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/MultiIconNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/MultiIconNotificationBuilder.kt
@@ -13,10 +13,7 @@ package com.adobe.marketing.mobile.notificationbuilder.internal.builders
 
 import android.app.Activity
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
-import android.os.Bundle
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.notificationbuilder.NotificationConstructionFailedException
@@ -27,7 +24,6 @@ import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setRem
 import com.adobe.marketing.mobile.notificationbuilder.internal.extensions.setRemoteViewImage
 import com.adobe.marketing.mobile.notificationbuilder.internal.templates.MultiIconPushTemplate
 import com.adobe.marketing.mobile.services.Log
-import java.util.Random
 
 internal object MultiIconNotificationBuilder {
     const val SELF_TAG = "MultiIconNotificationBuilder"
@@ -68,23 +64,15 @@ internal object MultiIconNotificationBuilder {
             pushTemplate
         )
 
-        val closeButtonIntentExtra = Bundle(pushTemplate.data.getBundle()) // copy the bundle
-        closeButtonIntentExtra.putString(PushTemplateConstants.PushPayloadKeys.STICKY, "false")
-        val dismissIntent = Intent(PushTemplateConstants.NotificationAction.DISMISSED)
-        trackerActivityClass?.let {
-            dismissIntent.setClass(context.applicationContext, trackerActivityClass)
-        }
-        dismissIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-        dismissIntent.putExtras(closeButtonIntentExtra)
-        val pendingIntent = PendingIntent.getActivity(
+        // set the click action for the close button
+        notificationLayout.setRemoteViewClickAction(
             context,
-            Random().nextInt(),
-            dismissIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        notificationLayout.setOnClickPendingIntent(
+            trackerActivityClass,
             R.id.five_icon_close_button,
-            pendingIntent
+            null,
+            null,
+            PushTemplateConstants.ActionType.DISMISS,
+            pushTemplate.data.getBundle()
         )
 
         return AEPPushNotificationBuilder.construct(
@@ -122,14 +110,13 @@ internal object MultiIconNotificationBuilder {
             }
 
             trackerActivityClass?.let {
-                val interactionUri = item.actionUri ?: pushTemplate.actionUri
                 iconItem.setRemoteViewClickAction(
                     context,
                     trackerActivityClass,
                     R.id.icon_item_image_view,
-                    interactionUri,
+                    item.actionUri,
                     null,
-                    null,
+                    item.actionType,
                     pushTemplate.data.getBundle()
                 )
             }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/MultiIconNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/MultiIconNotificationBuilder.kt
@@ -129,6 +129,7 @@ internal object MultiIconNotificationBuilder {
                     R.id.icon_item_image_view,
                     interactionUri,
                     null,
+                    null,
                     pushTemplate.data.getBundle()
                 )
             }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductCatalogNotificationBuilder.kt
@@ -155,6 +155,7 @@ internal object ProductCatalogNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.catalogItems[pushTemplate.currentIndex].uri,
                 PushTemplateConstants.CatalogActionIds.PRODUCT_IMAGE_CLICKED,
+                null,
                 pushTemplate.data.getBundle()
             )
         )
@@ -248,6 +249,7 @@ internal object ProductCatalogNotificationBuilder {
                 trackerActivityClass,
                 pushTemplate.ctaButtonUri,
                 PushTemplateConstants.CatalogActionIds.CTA_BUTTON_CLICKED,
+                null,
                 pushTemplate.data.getBundle()
             )
         )

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilder.kt
@@ -116,6 +116,7 @@ internal object ProductRatingNotificationBuilder {
                 R.id.rating_confirm,
                 selectedRatingAction.link,
                 pushTemplate.ratingSelected.toString(),
+                pushTemplate.ratingActionList[pushTemplate.ratingSelected].type,
                 ratingConfirmedIntentExtras
             )
         } else {

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
@@ -181,13 +181,15 @@ internal fun NotificationCompat.Builder.setLargeIcon(
  *
  * @param context the application [Context]
  * @param trackerActivityClass the [Class] of the activity to set in the created pending intent for tracking purposes
- * @param actionUri `String` containing the action uri
+ * @param actionUri [String] containing the action uri
+ * @param actionType the [PushTemplateConstants.ActionType] of the action
  * @param intentExtras the [Bundle] containing the extras to be added to the intent
  */
 internal fun NotificationCompat.Builder.setNotificationClickAction(
     context: Context,
     trackerActivityClass: Class<out Activity>?,
     actionUri: String?,
+    actionType: PushTemplateConstants.ActionType?,
     intentExtras: Bundle?
 ): NotificationCompat.Builder {
     val pendingIntent: PendingIntent? = PendingIntentUtils.createPendingIntentForTrackerActivity(
@@ -195,6 +197,7 @@ internal fun NotificationCompat.Builder.setNotificationClickAction(
         trackerActivityClass,
         actionUri,
         null,
+        actionType?.name,
         intentExtras
     )
     setContentIntent(pendingIntent)
@@ -255,6 +258,7 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     trackerActivityClass,
                     eachButton.link,
                     eachButton.label,
+                    null,
                     intentExtras
                 )
             } else {
@@ -263,6 +267,7 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     trackerActivityClass,
                     null,
                     eachButton.label,
+                    null,
                     intentExtras
                 )
             }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
@@ -258,7 +258,7 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     trackerActivityClass,
                     eachButton.link,
                     eachButton.label,
-                    null,
+                    eachButton.type,
                     intentExtras
                 )
             } else {
@@ -267,7 +267,7 @@ internal fun NotificationCompat.Builder.addActionButtons(
                     trackerActivityClass,
                     null,
                     eachButton.label,
-                    null,
+                    eachButton.type,
                     intentExtras
                 )
             }

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/NotificationCompatBuilderExtensions.kt
@@ -197,7 +197,7 @@ internal fun NotificationCompat.Builder.setNotificationClickAction(
         trackerActivityClass,
         actionUri,
         null,
-        actionType?.name,
+        actionType,
         intentExtras
     )
     setContentIntent(pendingIntent)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
@@ -179,6 +179,7 @@ internal fun RemoteViews.setRemoteViewImage(
  * @param targetViewResourceId [Int] containing the resource id of the view to attach the click action
  * @param actionUri [String] containing the action uri defined for the push template image
  * @param actionId the [String] containing action id for tracking purposes
+ * @param actionType the [PushTemplateConstants.ActionType] of the click action
  * @param intentExtra the [Bundle] containing the extras to be added to the intent
  */
 internal fun RemoteViews.setRemoteViewClickAction(
@@ -187,6 +188,7 @@ internal fun RemoteViews.setRemoteViewClickAction(
     targetViewResourceId: Int,
     actionUri: String?,
     actionId: String?,
+    actionType: PushTemplateConstants.ActionType?,
     intentExtra: Bundle?
 ) {
     Log.trace(
@@ -195,12 +197,21 @@ internal fun RemoteViews.setRemoteViewClickAction(
         "Setting remote view click action uri: $actionUri."
     )
 
+    actionType?.let {
+        Log.trace(
+            LOG_TAG,
+            SELF_TAG,
+            "Setting remote view click action type: ${actionType.name}."
+        )
+    }
+
     val pendingIntent: PendingIntent? =
         PendingIntentUtils.createPendingIntentForTrackerActivity(
             context,
             trackerActivityClass,
             actionUri,
             actionId,
+            actionType?.name,
             intentExtra
         )
     setOnClickPendingIntent(targetViewResourceId, pendingIntent)

--- a/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
+++ b/code/notificationbuilder/src/main/java/com/adobe/marketing/mobile/notificationbuilder/internal/extensions/RemoteViewsExtensions.kt
@@ -211,7 +211,7 @@ internal fun RemoteViews.setRemoteViewClickAction(
             trackerActivityClass,
             actionUri,
             actionId,
-            actionType?.name,
+            actionType,
             intentExtra
         )
     setOnClickPendingIntent(targetViewResourceId, pendingIntent)

--- a/code/notificationbuilder/src/main/res/layout/push_tempate_vertical_catalog.xml
+++ b/code/notificationbuilder/src/main/res/layout/push_tempate_vertical_catalog.xml
@@ -35,7 +35,7 @@
         android:layout_marginBottom="@dimen/product_catalog_price_bottom_margin"
         android:layout_marginLeft="@dimen/product_catalog_price_side_margin"
         android:layout_toRightOf="@id/product_image"
-        android:text="@string/price"
+        android:text="@string/aep_price"
         android:textAlignment="viewStart"
         android:textStyle="normal|bold" />
 
@@ -46,7 +46,7 @@
         android:layout_below="@id/product_price"
         android:layout_marginLeft="@dimen/product_catalog_price_side_margin"
         android:layout_toRightOf="@id/product_image"
-        android:text="@string/buy_now"
+        android:text="@string/aep_buy_now"
         android:textAlignment="center"
         android:textSize="12sp" />
 
@@ -66,7 +66,7 @@
             android:layout_marginTop="@dimen/product_catalog_mini_top_margin"
             android:layout_marginLeft="@dimen/product_catalog_price_side_margin"
             android:baselineAlignBottom="true"
-            android:contentDescription="@string/product_thumbnail_1" />
+            android:contentDescription="@string/aep_product_thumbnail_1" />
 
         <ImageView
             android:id="@+id/product_thumbnail_2"
@@ -77,7 +77,7 @@
             android:layout_marginTop="@dimen/product_catalog_mini_top_margin"
             android:layout_marginLeft="@dimen/product_catalog_mini_side_margin"
             android:baselineAlignBottom="true"
-            android:contentDescription="@string/product_thumbnail_2" />
+            android:contentDescription="@string/aep_product_thumbnail_2" />
 
         <ImageView
             android:id="@+id/product_thumbnail_3"
@@ -88,7 +88,7 @@
             android:layout_marginTop="@dimen/product_catalog_mini_top_margin"
             android:layout_marginLeft="@dimen/product_catalog_mini_side_margin"
             android:baselineAlignBottom="true"
-            android:contentDescription="@string/product_thumbnail_3" />
+            android:contentDescription="@string/aep_product_thumbnail_3" />
     </LinearLayout>
 
     <ImageView
@@ -100,5 +100,5 @@
         android:layout_alignParentLeft="true"
         android:layout_below="@id/product_description"
         android:layout_alignBottom="@id/vertical_catalog_thumbnail_layout"
-        android:contentDescription="@string/big_product_image"/>
+        android:contentDescription="@string/aep_big_product_image"/>
 </RelativeLayout>

--- a/code/notificationbuilder/src/main/res/layout/push_template_horizontal_catalog.xml
+++ b/code/notificationbuilder/src/main/res/layout/push_template_horizontal_catalog.xml
@@ -15,7 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/product_catalog_image_height"
         android:layout_alignParentLeft="true"
-        android:contentDescription="@string/big_product_image">
+        android:contentDescription="@string/aep_big_product_image">
     </ImageView>
 
     <LinearLayout
@@ -43,7 +43,7 @@
             android:layout_width="@dimen/product_catalog_horizontal_mid_row_width"
             android:layout_height="wrap_content"
             android:padding="@dimen/standard_title_bottom_margin"
-            android:text="@string/buy_now"
+            android:text="@string/aep_buy_now"
             android:textAlignment="center"
             android:textSize="12sp" />
     </LinearLayout>
@@ -62,7 +62,7 @@
             android:scaleType="center"
             android:layout_height="@dimen/product_catalog_horizontal_bottom_row_height"
             android:layout_width="@dimen/product_catalog_horizontal_bottom_row_width"
-            android:contentDescription="@string/product_thumbnail_1"/>
+            android:contentDescription="@string/aep_product_thumbnail_1"/>
 
         <ImageView
             android:id="@+id/product_thumbnail_2"
@@ -71,7 +71,7 @@
             android:layout_height="@dimen/product_catalog_horizontal_bottom_row_height"
             android:layout_width="@dimen/product_catalog_horizontal_bottom_row_width"
             android:layout_marginLeft="@dimen/product_catalog_horizontal_bottom_row_margin_left"
-            android:contentDescription="@string/product_thumbnail_2"/>
+            android:contentDescription="@string/aep_product_thumbnail_2"/>
 
         <ImageView
             android:id="@+id/product_thumbnail_3"
@@ -80,7 +80,7 @@
             android:layout_height="@dimen/product_catalog_horizontal_bottom_row_height"
             android:layout_width="@dimen/product_catalog_horizontal_bottom_row_width"
             android:layout_marginLeft="@dimen/product_catalog_horizontal_bottom_row_margin_left"
-            android:contentDescription="@string/product_thumbnail_3"/>
+            android:contentDescription="@string/aep_product_thumbnail_3"/>
     </LinearLayout>
 
 </RelativeLayout>

--- a/code/notificationbuilder/src/main/res/layout/push_template_multi_icon.xml
+++ b/code/notificationbuilder/src/main/res/layout/push_template_multi_icon.xml
@@ -10,7 +10,7 @@
         android:id="@+id/five_icon_close_button"
         android:layout_width="@dimen/multi_icon_close_button_height"
         android:layout_height="@dimen/multi_icon_close_button_height"
-        android:contentDescription="@string/multi_icon_close_btn_content_description"
+        android:contentDescription="@string/aep_multi_icon_close_btn_content_description"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:padding="@dimen/multi_icon_item_padding"

--- a/code/notificationbuilder/src/main/res/layout/push_template_product_rating_expanded.xml
+++ b/code/notificationbuilder/src/main/res/layout/push_template_product_rating_expanded.xml
@@ -63,7 +63,7 @@
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/rating_confirm_padding"
         android:paddingBottom="@dimen/rating_confirm_padding"
-        android:text="@string/product_rating_confirm"
+        android:text="@string/aep_product_rating_confirm"
         android:gravity="center"
         style="@style/Title"
         android:visibility="invisible"/>

--- a/code/notificationbuilder/src/main/res/values/strings.xml
+++ b/code/notificationbuilder/src/main/res/values/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="buy_now">Buy Now</string>
-    <string name="price">Price</string>
-    <string name="large_icon">large icon</string>
-    <string name="product_thumbnail_1">product thumbnail 1</string>
-    <string name="product_thumbnail_2">product thumbnail 2</string>
-    <string name="product_thumbnail_3">product thumbnail 3</string>
-    <string name="big_product_image">big product image</string>
-    <string name="product_rating_confirm">Confirm</string>
-    <string name="multi_icon_close_btn_content_description">Close</string>
+    <string name="aep_buy_now">Buy Now</string>
+    <string name="aep_price">Price</string>
+    <string name="aep_large_icon">large icon</string>
+    <string name="aep_product_thumbnail_1">product thumbnail 1</string>
+    <string name="aep_product_thumbnail_2">product thumbnail 2</string>
+    <string name="aep_product_thumbnail_3">product thumbnail 3</string>
+    <string name="aep_big_product_image">big product image</string>
+    <string name="aep_product_rating_confirm">Confirm</string>
+    <string name="aep_multi_icon_close_btn_content_description">Close</string>
 </resources>

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilderTests.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilderTests.kt
@@ -118,7 +118,7 @@ class NotificationBuilderTests {
     fun `NotificationBuilder version values matches the expected version`() {
         val version = NotificationBuilder.version()
 
-        assertEquals("3.0.1", version)
+        assertEquals("3.0.2", version)
     }
 
     @Test

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilderTests.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/NotificationBuilderTests.kt
@@ -118,7 +118,7 @@ class NotificationBuilderTests {
     fun `NotificationBuilder version values matches the expected version`() {
         val version = NotificationBuilder.version()
 
-        assertEquals("3.0.0", version)
+        assertEquals("3.0.1", version)
     }
 
     @Test

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/AutoCarouselNotificationBuilderTest.kt
@@ -125,7 +125,7 @@ class AutoCarouselNotificationBuilderTest {
         every { getCachedImage(any()) } answers { cachedItem }
         every { anyConstructed<RemoteViews>().setImageViewBitmap(any(), any()) } just Runs
         every { anyConstructed<RemoteViews>().setTextViewText(any(), any()) } just Runs
-        every { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, any()) } just Runs
+        every { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, null, any()) } just Runs
         every { expandedLayout.addView(any(), any<RemoteViews>()) } just Runs
         val imagesList = AutoCarouselNotificationBuilder.populateAutoCarouselImages(
             context,
@@ -138,7 +138,7 @@ class AutoCarouselNotificationBuilderTest {
         assertFalse(imagesList.isEmpty())
         verify(exactly = imagesList.size) { getCachedImage(any()) }
         verify(exactly = imagesList.size) { anyConstructed<RemoteViews>().setImageViewBitmap(any(), any()) }
-        verify(exactly = imagesList.size) { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, any()) }
+        verify(exactly = imagesList.size) { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, null, any()) }
         verify(exactly = imagesList.size) { anyConstructed<RemoteViews>().setTextViewText(any(), any()) }
     }
 
@@ -148,7 +148,7 @@ class AutoCarouselNotificationBuilderTest {
         every { getCachedImage(any()) } answers { cachedItem }
         every { anyConstructed<RemoteViews>().setImageViewBitmap(any(), any()) } just Runs
         every { anyConstructed<RemoteViews>().setTextViewText(any(), any()) } just Runs
-        every { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, any()) } just Runs
+        every { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, null, any()) } just Runs
         every { expandedLayout.addView(any(), any<RemoteViews>()) } just Runs
         val imagesList = AutoCarouselNotificationBuilder.populateAutoCarouselImages(
             context,
@@ -161,7 +161,7 @@ class AutoCarouselNotificationBuilderTest {
         assertFalse(imagesList.isEmpty())
         verify(exactly = imagesList.size) { getCachedImage(any()) }
         verify(exactly = imagesList.size) { anyConstructed<RemoteViews>().setImageViewBitmap(any(), any()) }
-        verify(exactly = 0) { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, any()) }
+        verify(exactly = 0) { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, null, any()) }
         verify(exactly = imagesList.size) { anyConstructed<RemoteViews>().setTextViewText(any(), any()) }
     }
 
@@ -178,7 +178,7 @@ class AutoCarouselNotificationBuilderTest {
         )
         assertTrue(imagesList.isEmpty())
         verify(exactly = 0) { anyConstructed<RemoteViews>().setImageViewBitmap(any(), any()) }
-        verify(exactly = 0) { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, any()) }
+        verify(exactly = 0) { anyConstructed<RemoteViews>().setRemoteViewClickAction(context, trackerActivityClass, any(), any(), null, null, any()) }
         verify(exactly = 0) { anyConstructed<RemoteViews>().setTextViewText(any(), any()) }
     }
 

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ManualCarouselNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ManualCarouselNotificationBuilderTest.kt
@@ -304,6 +304,7 @@ class ManualCarouselNotificationBuilderTest {
                 any(),
                 any(),
                 null,
+                null,
                 any()
             )
         } just Runs
@@ -337,6 +338,7 @@ class ManualCarouselNotificationBuilderTest {
                 trackerActivityClass,
                 any(),
                 any(),
+                null,
                 null,
                 any()
             )
@@ -373,6 +375,7 @@ class ManualCarouselNotificationBuilderTest {
                 any(),
                 any(),
                 null,
+                null,
                 any()
             )
         }
@@ -395,6 +398,7 @@ class ManualCarouselNotificationBuilderTest {
                 any(),
                 any(),
                 null,
+                null,
                 any()
             )
         } returns Unit
@@ -416,6 +420,7 @@ class ManualCarouselNotificationBuilderTest {
                 any(),
                 any(),
                 null,
+                null,
                 any()
             )
         }
@@ -436,6 +441,7 @@ class ManualCarouselNotificationBuilderTest {
                 any(),
                 any(),
                 null,
+                null,
                 any()
             )
         } returns Unit
@@ -453,6 +459,7 @@ class ManualCarouselNotificationBuilderTest {
                 trackerActivityClass,
                 any(),
                 any(),
+                null,
                 null,
                 any()
             )

--- a/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilderTest.kt
+++ b/code/notificationbuilder/src/test/java/com/adobe/marketing/mobile/notificationbuilder/internal/builders/ProductRatingNotificationBuilderTest.kt
@@ -134,7 +134,7 @@ class ProductRatingNotificationBuilderTest {
         val notificationBuilder = ProductRatingNotificationBuilder.construct(context, pushTemplate, trackerActivityClass, broadcastReceiverClass)
 
         verify(exactly = 1) { anyConstructed<RemoteViews>().setViewVisibility(R.id.rating_confirm, View.VISIBLE) }
-        verify(exactly = 1) { any<RemoteViews>().setRemoteViewClickAction(any(), trackerActivityClass, R.id.rating_confirm, any(), "3", any()) }
+        verify(exactly = 1) { any<RemoteViews>().setRemoteViewClickAction(any(), trackerActivityClass, R.id.rating_confirm, any(), "3", PushTemplateConstants.ActionType.WEBURL, any()) }
     }
 
     @Test

--- a/code/testapp/src/main/AndroidManifest.xml
+++ b/code/testapp/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
@@ -11,8 +11,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Aepsdkandroid" >
+        android:theme="@style/Theme.Aepsdkandroid">
         <receiver android:name=".notificationBuilder.NotificationBroadcastReceiver" />
+
         <activity
             android:name=".notificationBuilder.NotificationTrackerActivity"
             android:exported="false"
@@ -24,6 +25,7 @@
             android:theme="@style/Theme.Aepsdkandroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -31,6 +33,21 @@
             android:name=".notificationBuilder.UINotificationBuilderActivity"
             android:exported="false"
             android:theme="@style/Theme.Aepsdkandroid" />
+
+        <activity
+            android:name=".DeeplinkActivity"
+            android:exported="true"
+            android:label="Deeplink Activity">
+            <intent-filter android:autoVerify="true">
+                <action android:name=".DeeplinkActivity" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="uitest"
+                    android:host="deeplink_activity"/>
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/code/testapp/src/main/assets/fiveicon/fiveicon.json
+++ b/code/testapp/src/main/assets/fiveicon/fiveicon.json
@@ -13,6 +13,6 @@
   "adb_tag" : "multi_icon",
   "customKey": "custom data",
   "adb_channel_id": "2024",
-  "adb_items": "[{\"img\":\"walk\",\"uri\":\"myapp://chooseShoeType/shoe1\",\"type\":\"DEEPLINK\"},{\"img\":\"drive\",\"uri\":\"myapp://chooseShoeType/bus\",\"type\":\"DEEPLINK\"},{\"img\":\"bus\",\"uri\":\"myapp://chooseShoeType/shoe3\",\"type\":\"DEEPLINK\"},{\"img\":\"taxi\",\"uri\":\"myapp://chooseShoeType/shoe4\",\"type\":\"DEEPLINK\"},{\"img\":\"fly\",\"uri\":\"myapp://chooseShoeType/shoe5\",\"type\":\"DEEPLINK\"}]",
+  "adb_items": "[{\"img\":\"walk\",\"uri\":\"https://www.nps.gov/index.htm\",\"type\":\"WEBURL\"},{\"img\":\"drive\",\"uri\":\"myapp://chooseShoeType/bus\",\"type\":\"DEEPLINK\"},{\"img\":\"bus\",\"uri\":\"myapp://chooseShoeType/shoe3\",\"type\":\"DISMISS\"},{\"img\":\"taxi\",\"uri\":\"myapp://chooseShoeType/shoe4\",\"type\":\"OPENAPP\"},{\"img\":\"fly\",\"uri\":\"uitest://deeplink_activity\",\"type\":\"DEEPLINK\"}]",
   "adb_sticky": "true"
 }

--- a/code/testapp/src/main/assets/rating/rating.json
+++ b/code/testapp/src/main/assets/rating/rating.json
@@ -19,7 +19,7 @@
   "adb_large_icon": "https://cdn-icons-png.flaticon.com/128/864/864639.png",
   "adb_rate_selected_icon":"rating_star_filled",
   "adb_rate_unselected_icon":"rating_star_outline",
-  "adb_rate_act": "[{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"DISMISS\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\": \"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"OPENAPP\"}]",
+  "adb_rate_act": "[{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"DISMISS\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\": \"uitest://deeplink_activity\", \"type\":\"DEEPLINK\"},{\"type\":\"OPENAPP\"}]",
   "adb_tag": "rating",
-  "adb_sticky": "true"
+  "adb_sticky": "false"
 }

--- a/code/testapp/src/main/assets/rating/rating.json
+++ b/code/testapp/src/main/assets/rating/rating.json
@@ -19,7 +19,7 @@
   "adb_large_icon": "https://cdn-icons-png.flaticon.com/128/864/864639.png",
   "adb_rate_selected_icon":"rating_star_filled",
   "adb_rate_unselected_icon":"rating_star_outline",
-  "adb_rate_act": "[{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"OPENAPP\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\": \"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"}]",
+  "adb_rate_act": "[{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"DISMISS\"},{\"uri\":\"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"uri\": \"https://www.adobe.com\", \"type\":\"WEBURL\"},{\"type\":\"OPENAPP\"}]",
   "adb_tag": "rating",
   "adb_sticky": "true"
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/notificationbuilder/testapp/DeeplinkActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/notificationbuilder/testapp/DeeplinkActivity.kt
@@ -1,0 +1,58 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+package com.adobe.marketing.mobile.notificationbuilder.testapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.ui.Modifier
+import android.content.Intent
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.adobe.marketing.mobile.notificationbuilder.testapp.ui.theme.AepsdkTheme
+
+class DeeplinkActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AepsdkTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colors.secondaryVariant
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "This is the deeplink launched activity",
+                            modifier = Modifier.padding(16.dp),
+                            fontSize = 30.sp,
+                            textAlign = TextAlign.Center,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(modifier = Modifier.height(40.dp))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/notificationbuilder/testapp/notificationBuilder/NotificationTrackerActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/notificationbuilder/testapp/notificationBuilder/NotificationTrackerActivity.kt
@@ -33,11 +33,19 @@ class NotificationTrackerActivity : AppCompatActivity() {
                 Log.debug("MyApp", "NotificationTrackerActivity", "input box quick reply result: $quickReplyResult")
             }
             PushTemplateConstants.NotificationAction.CLICKED -> executePushAction(intent)
+            PushTemplateConstants.NotificationAction.DISMISSED -> removeNotification(intent)
             else -> {}
         }
 
         finish()
         return
+    }
+
+    private fun removeNotification(intent: Intent) {
+        val tag = intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.TAG)
+        val context = ServiceProvider.getInstance().appContextService.applicationContext ?: return
+        val notificationManager = NotificationManagerCompat.from(context)
+        notificationManager.cancel(tag.hashCode())
     }
 
     private fun executePushAction(intent: Intent) {
@@ -54,10 +62,7 @@ class NotificationTrackerActivity : AppCompatActivity() {
         if (isStickyNotification) {
             return
         }
-        val tag = intent.getStringExtra(PushTemplateConstants.PushPayloadKeys.TAG)
-        val context = ServiceProvider.getInstance().appContextService.applicationContext ?: return
-        val notificationManager = NotificationManagerCompat.from(context)
-        notificationManager.cancel(tag.hashCode())
+        removeNotification(intent)
     }
 
     private fun openApplication() {
@@ -90,7 +95,7 @@ class NotificationTrackerActivity : AppCompatActivity() {
             }
             startActivity(deeplinkIntent)
         } catch (e: ActivityNotFoundException) {
-
+            Log.trace("NotificationTrackerActivity", "openUri", "Activity not found for URI: $uri")
         }
     }
 }

--- a/code/testapp/src/main/res/layout/activity_deeplink.xml
+++ b/code/testapp/src/main/res/layout/activity_deeplink.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DeeplinkActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
All created pending intents had `NotificationAction.CLICKED` as their action type which wasn't allowing the ACC extension's `CampaignPushTrackerActivity` to properly handle a received dismissed intent. To resolve the issue, a dismissed pending intent is created when action type is dismissed (`ActionType.DISMISS`). All other pending intents will continue to use `NotificationAction.CLICKED` as their action type.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
